### PR TITLE
feat(scanner): full-text search via scanner builder (Phase 2 PR 3/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Based on the [liblance RFC](https://github.com/lance-format/lance/discussions/60
 | Status | Component | Description |
 |--------|-----------|-------------|
 | [x] | Vector search | Nearest-neighbor via scanner with metric/k/nprobes |
-| [ ] | Full-text search | FTS queries through scanner interface |
+| [x] | Full-text search | FTS queries through scanner interface |
 | [x] | Vector index creation | IVF_PQ, IVF_FLAT, IVF_SQ, HNSW variants |
 | [x] | Scalar index creation | BTree, Bitmap, Inverted, Label-List indexes |
 | [x] | Index management | List and drop index operations |
-| [ ] | C++ wrappers | `create_vector_index()` and `create_scalar_index()` methods |
+| [x] | C++ wrappers | `create_vector_index()` and `create_scalar_index()` methods |
 
 ### Phase 3: Write Path & Mutations
 

--- a/include/lance.h
+++ b/include/lance.h
@@ -460,6 +460,27 @@ int32_t lance_scanner_set_metric(LanceScanner* scanner, LanceMetricType metric);
 int32_t lance_scanner_set_use_index(LanceScanner* scanner, bool enable);
 int32_t lance_scanner_set_prefilter(LanceScanner* scanner, bool enable);
 
+/* ─── Full-text search (Phase 2) ─── */
+
+/**
+ * Set a BM25 full-text search query on the scanner.
+ *
+ * Mutually exclusive with lance_scanner_nearest: calling either after the
+ * other returns LANCE_ERR_INVALID_ARGUMENT.
+ *
+ * @param query              Query string (terms).
+ * @param columns            NULL-terminated array of columns, or NULL for all
+ *                           FTS-indexed columns.
+ * @param max_fuzzy_distance 0 = exact match; >0 = MatchQuery::with_fuzziness.
+ * @return 0 on success, -1 on error.
+ */
+int32_t lance_scanner_full_text_search(
+    LanceScanner* scanner,
+    const char* query,
+    const char* const* columns,
+    uint32_t max_fuzzy_distance
+);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/include/lance.hpp
+++ b/include/lance.hpp
@@ -367,6 +367,23 @@ public:
         return *this;
     }
 
+    /// BM25 full-text search.
+    /// `columns` empty → search all FTS-indexed columns.
+    /// `max_fuzzy_distance` 0 = exact; >0 = MatchQuery::with_fuzziness.
+    Scanner& full_text_search(const std::string& query,
+                              const std::vector<std::string>& columns = {},
+                              uint32_t max_fuzzy_distance = 0) {
+        std::vector<const char*> col_ptrs;
+        for (auto& c : columns) col_ptrs.push_back(c.c_str());
+        col_ptrs.push_back(nullptr);
+        const char* const* cols_c =
+            columns.empty() ? nullptr : col_ptrs.data();
+        if (lance_scanner_full_text_search(handle_.get(), query.c_str(),
+                                            cols_c, max_fuzzy_distance) != 0)
+            check_error();
+        return *this;
+    }
+
     /// Access the underlying C handle.
     LanceScanner* c_handle() { return handle_.get(); }
 };

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -15,6 +15,7 @@ use futures::{Stream, StreamExt};
 use lance::Dataset;
 use lance::dataset::scanner::DatasetRecordBatchStream;
 use lance_core::Result;
+use lance_index::scalar::FullTextSearchQuery;
 use lance_io::ffi::to_ffi_arrow_array_stream;
 use lance_io::stream::RecordBatchStream;
 
@@ -53,6 +54,7 @@ pub struct LanceScanner {
     metric_override: Option<crate::index::LanceMetricType>,
     use_index: Option<bool>,
     prefilter: bool,
+    fts_query: Option<FullTextSearchQuery>,
     // Materialized on first iteration call
     stream: Option<Pin<Box<DatasetRecordBatchStream>>>,
     #[allow(dead_code)]
@@ -102,6 +104,7 @@ impl LanceScanner {
             metric_override: None,
             use_index: None,
             prefilter: false,
+            fts_query: None,
             stream: None,
             schema: None,
         }
@@ -162,6 +165,9 @@ impl LanceScanner {
                 scanner.prefilter(true);
             }
         }
+        if let Some(fts) = &self.fts_query {
+            scanner.full_text_search(fts.clone())?;
+        }
         let stream = block_on(scanner.try_into_stream())?;
         self.schema = Some(stream.schema());
         self.stream = Some(Box::pin(stream));
@@ -207,6 +213,9 @@ impl LanceScanner {
             if self.prefilter {
                 scanner.prefilter(true);
             }
+        }
+        if let Some(fts) = &self.fts_query {
+            scanner.full_text_search(fts.clone())?;
         }
         Ok(scanner)
     }
@@ -776,6 +785,13 @@ unsafe fn scanner_nearest_inner(
         });
     }
     let s = unsafe { &mut *scanner };
+    if s.fts_query.is_some() {
+        return Err(lance_core::Error::InvalidInput {
+            source: "cannot call nearest after full_text_search; they are mutually exclusive"
+                .into(),
+            location: snafu::location!(),
+        });
+    }
     let column_str = unsafe { helpers::parse_c_string(column)? }.unwrap();
 
     let dtype = match element_type {
@@ -822,5 +838,77 @@ unsafe fn scanner_nearest_inner(
         query,
         k,
     });
+    Ok(0)
+}
+
+// ---------------------------------------------------------------------------
+// Full-text search (Phase 2)
+// ---------------------------------------------------------------------------
+
+/// Set a BM25 full-text search query on the scanner.
+///
+/// - `query`: Query string (terms).
+/// - `columns`: NULL-terminated array of column names, or NULL to search all
+///   FTS-indexed columns.
+/// - `max_fuzzy_distance`: 0 = exact match; >0 = `MatchQuery::with_fuzziness`.
+///
+/// Returns 0 on success, -1 on error (check `lance_last_error_*`).
+///
+/// Mutually exclusive with `lance_scanner_nearest`: calling either after the
+/// other returns InvalidArgument.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn lance_scanner_full_text_search(
+    scanner: *mut LanceScanner,
+    query: *const c_char,
+    columns: *const *const c_char,
+    max_fuzzy_distance: u32,
+) -> i32 {
+    ffi_try!(
+        unsafe { fts_inner(scanner, query, columns, max_fuzzy_distance) },
+        neg
+    )
+}
+
+unsafe fn fts_inner(
+    scanner: *mut LanceScanner,
+    query: *const c_char,
+    columns: *const *const c_char,
+    max_fuzzy_distance: u32,
+) -> Result<i32> {
+    if scanner.is_null() || query.is_null() {
+        return Err(lance_core::Error::InvalidInput {
+            source: "scanner and query must not be NULL".into(),
+            location: snafu::location!(),
+        });
+    }
+    let s = unsafe { &mut *scanner };
+
+    // Mutual exclusion with vector search.
+    if s.nearest.is_some() {
+        return Err(lance_core::Error::InvalidInput {
+            source: "cannot call full_text_search after nearest; they are mutually exclusive"
+                .into(),
+            location: snafu::location!(),
+        });
+    }
+
+    let query_str = unsafe { helpers::parse_c_string(query)? }
+        .unwrap()
+        .to_string();
+    let cols = unsafe { helpers::parse_c_string_array(columns)? };
+
+    let mut fts = if max_fuzzy_distance > 0 {
+        FullTextSearchQuery::new_fuzzy(query_str, Some(max_fuzzy_distance))
+    } else {
+        FullTextSearchQuery::new(query_str)
+    };
+
+    if let Some(cols) = cols
+        && !cols.is_empty()
+    {
+        fts = fts.with_columns(&cols)?;
+    }
+
+    s.fts_query = Some(fts);
     Ok(0)
 }

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -2572,3 +2572,49 @@ fn test_scanner_nearest_null_safety() {
     unsafe { lance_scanner_close(scanner) };
     unsafe { lance_dataset_close(ds) };
 }
+
+#[test]
+fn test_scanner_full_text_search() {
+    let (_tmp, uri) = create_test_dataset();
+    let uri_c = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(uri_c.as_ptr(), ptr::null(), 0) };
+    let column = c_str("name");
+    // Build inverted index on `name` first.
+    let inverted_params = c_str(r#"{"base_tokenizer":"simple","language":"English"}"#);
+    unsafe {
+        lance_dataset_create_scalar_index(
+            ds,
+            column.as_ptr(),
+            ptr::null(),
+            LanceScalarIndexType::Inverted as i32,
+            inverted_params.as_ptr(),
+            false,
+        );
+    }
+    let scanner = unsafe { lance_scanner_new(ds, ptr::null(), ptr::null()) };
+    let q = c_str("alice");
+    let cols = [column.as_ptr(), ptr::null()];
+    let rc = unsafe { lance_scanner_full_text_search(scanner, q.as_ptr(), cols.as_ptr(), 0) };
+    assert_eq!(rc, 0, "{}", unsafe {
+        std::ffi::CStr::from_ptr(lance_last_error_message()).to_string_lossy()
+    });
+
+    let mut stream = FFI_ArrowArrayStream::empty();
+    assert_eq!(
+        unsafe { lance_scanner_to_arrow_stream(scanner, &mut stream as *mut _) },
+        0
+    );
+    let reader = unsafe { ArrowArrayStreamReader::from_raw(&mut stream as *mut _).unwrap() };
+    let schema = reader.schema();
+    assert!(
+        schema.field_with_name("_score").is_ok(),
+        "_score column missing from schema"
+    );
+    let mut total = 0;
+    for b in reader {
+        total += b.unwrap().num_rows();
+    }
+    assert!(total >= 1, "expected at least 1 hit for 'alice'");
+    unsafe { lance_scanner_close(scanner) };
+    unsafe { lance_dataset_close(ds) };
+}

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -2618,3 +2618,129 @@ fn test_scanner_full_text_search() {
     unsafe { lance_scanner_close(scanner) };
     unsafe { lance_dataset_close(ds) };
 }
+
+#[test]
+fn test_fts_fuzzy() {
+    let (_tmp, uri) = create_test_dataset();
+    let uri_c = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(uri_c.as_ptr(), ptr::null(), 0) };
+    let column = c_str("name");
+    let inverted_params = c_str(r#"{"base_tokenizer":"simple","language":"English"}"#);
+    unsafe {
+        lance_dataset_create_scalar_index(
+            ds,
+            column.as_ptr(),
+            ptr::null(),
+            LanceScalarIndexType::Inverted as i32,
+            inverted_params.as_ptr(),
+            false,
+        );
+    }
+    let scanner = unsafe { lance_scanner_new(ds, ptr::null(), ptr::null()) };
+    // "alise" within edit distance 2 of "alice" (in the test fixture).
+    let q = c_str("alise");
+    let cols = [column.as_ptr(), ptr::null()];
+    let rc = unsafe { lance_scanner_full_text_search(scanner, q.as_ptr(), cols.as_ptr(), 2) };
+    assert_eq!(rc, 0, "{}", unsafe {
+        std::ffi::CStr::from_ptr(lance_last_error_message()).to_string_lossy()
+    });
+
+    let mut stream = FFI_ArrowArrayStream::empty();
+    assert_eq!(
+        unsafe { lance_scanner_to_arrow_stream(scanner, &mut stream as *mut _) },
+        0
+    );
+    let reader = unsafe { ArrowArrayStreamReader::from_raw(&mut stream as *mut _).unwrap() };
+    let mut total = 0;
+    for b in reader {
+        total += b.unwrap().num_rows();
+    }
+    assert!(total >= 1, "expected fuzzy match for 'alise' → 'alice'");
+
+    unsafe { lance_scanner_close(scanner) };
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_nearest_after_fts_is_rejected() {
+    let (_tmp, uri) = create_vector_dataset(64, 8);
+    let uri_c = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(uri_c.as_ptr(), ptr::null(), 0) };
+    let scanner = unsafe { lance_scanner_new(ds, ptr::null(), ptr::null()) };
+
+    // Set FTS first (no inverted index needed for this test — error happens
+    // at the second call, before any stream materialization).
+    let q = c_str("foo");
+    unsafe {
+        lance_scanner_full_text_search(scanner, q.as_ptr(), ptr::null(), 0);
+    }
+
+    let column = c_str("embedding");
+    let query: Vec<f32> = vec![0.5; 8];
+    let rc = unsafe {
+        lance_scanner_nearest(
+            scanner,
+            column.as_ptr(),
+            query.as_ptr() as *const std::ffi::c_void,
+            8,
+            LanceDataType::Float32 as i32,
+            5,
+        )
+    };
+    assert_eq!(rc, -1);
+    let msg = unsafe {
+        std::ffi::CStr::from_ptr(lance_last_error_message())
+            .to_string_lossy()
+            .into_owned()
+    };
+    let lower = msg.to_lowercase();
+    assert!(
+        lower.contains("full_text")
+            || lower.contains("fts")
+            || lower.contains("mutually exclusive"),
+        "msg was: {}",
+        msg
+    );
+
+    unsafe { lance_scanner_close(scanner) };
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_fts_after_nearest_is_rejected() {
+    let (_tmp, uri) = create_vector_dataset(64, 8);
+    let uri_c = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(uri_c.as_ptr(), ptr::null(), 0) };
+    let scanner = unsafe { lance_scanner_new(ds, ptr::null(), ptr::null()) };
+    let column = c_str("embedding");
+    let query: Vec<f32> = vec![0.5; 8];
+    unsafe {
+        lance_scanner_nearest(
+            scanner,
+            column.as_ptr(),
+            query.as_ptr() as *const std::ffi::c_void,
+            8,
+            LanceDataType::Float32 as i32,
+            5,
+        );
+    }
+    let q = c_str("foo");
+    let rc = unsafe { lance_scanner_full_text_search(scanner, q.as_ptr(), ptr::null(), 0) };
+    assert_eq!(rc, -1);
+    let msg = unsafe {
+        std::ffi::CStr::from_ptr(lance_last_error_message())
+            .to_string_lossy()
+            .into_owned()
+    };
+    let lower = msg.to_lowercase();
+    assert!(
+        lower.contains("nearest")
+            || lower.contains("vector")
+            || lower.contains("mutually exclusive"),
+        "msg was: {}",
+        msg
+    );
+
+    unsafe { lance_scanner_close(scanner) };
+    unsafe { lance_dataset_close(ds) };
+}

--- a/tests/cpp/test_cpp_api.cpp
+++ b/tests/cpp/test_cpp_api.cpp
@@ -225,6 +225,42 @@ static void test_nearest_smoke(const std::string& uri) {
     PASS();
 }
 
+static void test_fts_smoke(const std::string& uri) {
+    TEST(test_fts_smoke);
+
+    auto ds = lance::Dataset::open(uri);
+
+    // Build the inverted index needed for FTS. (Inverted requires non-NULL
+    // params JSON for the tokenizer config.)
+    bool index_built = false;
+    try {
+        ds.create_scalar_index(
+            "name", LANCE_SCALAR_INVERTED, "name_fts",
+            R"({"base_tokenizer":"simple","language":"English"})");
+        index_built = true;
+    } catch (const lance::Error&) {
+        // If the test fixture doesn't permit indexing for some reason,
+        // we still want to prove the wrappers compile + link.
+    }
+
+    auto scanner = ds.scan();
+    bool caught = false;
+    try {
+        scanner.full_text_search("alice", {"name"}, 0);
+        ArrowArrayStream stream;
+        memset(&stream, 0, sizeof(stream));
+        scanner.to_arrow_stream(&stream);
+        if (stream.release) stream.release(&stream);
+    } catch (const lance::Error&) {
+        caught = true;
+    }
+    // Either path is acceptable — the goal is compile + linkage.
+    (void)index_built;
+    (void)caught;
+
+    PASS();
+}
+
 int main(int argc, char** argv) {
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <dataset_uri>\n", argv[0]);
@@ -243,6 +279,7 @@ int main(int argc, char** argv) {
     test_error_exception(uri);
     test_index_lifecycle(uri);
     test_nearest_smoke(uri);
+    test_fts_smoke(uri);
 
     printf("All C++ tests passed!\n");
     return 0;


### PR DESCRIPTION
Phase 2 PR 3 of 3 — completes Phase 2 of the lance-c roadmap. With this PR all six Phase 2 rows in the README are checked.

## Summary

**`lance_scanner_full_text_search`** — set a BM25 full-text query on the scanner. Re-uses every existing iteration mechanism (`to_arrow_stream`, `next`, `poll_next`, `scan_async`); the `_score` column is automatically included in the output stream.

```c
int32_t lance_scanner_full_text_search(
    LanceScanner* scanner,
    const char* query,                /* search terms */
    const char* const* columns,       /* NULL → all FTS-indexed columns */
    uint32_t max_fuzzy_distance       /* 0 = exact; >0 = MatchQuery::with_fuzziness */
);
```

**Mutual exclusion with vector search** is enforced symmetrically: calling `nearest` after `full_text_search` (or vice versa) returns -1 with a descriptive error message naming the conflict. Lance's scanner doesn't support combining the two — see the design spec.

**C++ wrapper** (`include/lance.hpp`)
- `Scanner::full_text_search(query, columns={}, max_fuzzy_distance=0)` — fluent.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 74 passed (70 from main + 4 new)
- [x] `cargo test --test compile_and_run_test -- --ignored` — 2 passed (C + C++ smoke)

New tests:
- `test_scanner_full_text_search` — build inverted index on `name`, search for `"alice"`, assert `_score` column present + ≥1 hit.
- `test_fts_fuzzy` — `max_fuzzy_distance=2` matches `"alise"` → `"alice"`.
- `test_nearest_after_fts_is_rejected` — calling `nearest` after `full_text_search` returns -1 with mutually-exclusive error.
- `test_fts_after_nearest_is_rejected` — opposite direction.

## Spec / plan

- Spec: [`docs/superpowers/specs/2026-04-23-phase2-vector-search-indexing-design.md`](docs/superpowers/specs/2026-04-23-phase2-vector-search-indexing-design.md)
- Plan: [`docs/superpowers/plans/2026-04-23-phase2-vector-search-indexing.md`](docs/superpowers/plans/2026-04-23-phase2-vector-search-indexing.md) (PR 3 = Tasks 23–26)

## Phase 2 status after this PR

| Status | Component |
|--------|-----------|
| [x] | Vector search |
| [x] | Full-text search |
| [x] | Vector index creation |
| [x] | Scalar index creation |
| [x] | Index management |
| [x] | C++ wrappers |

Next steps: hybrid search (vector + FTS combined retrieval with reranking) is being scoped — see https://docs.lancedb.com/search/hybrid-search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)