### PR TITLE
feat(scanner): add lance_scanner_set_substrait_filter for Substrait filter pushdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,7 @@ dependencies = [
  "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -1340,6 +1341,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
+ "parquet",
  "rand 0.9.2",
  "regex",
  "sqlparser",
@@ -1413,6 +1415,7 @@ dependencies = [
  "libc",
  "log",
  "object_store",
+ "parquet",
  "paste",
  "sqlparser",
  "tokio",
@@ -1525,6 +1528,36 @@ dependencies = [
  "datafusion-session",
  "futures",
  "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-parquet"
+version = "52.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23798383465e0c569bd442d1453b50691261f8ad6511d840c48457b3bf51ae21"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "parquet",
  "tokio",
 ]
 
@@ -1905,6 +1938,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-substrait"
+version = "52.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2379388ecab67079eeb1185c953fb9c5ed4b283fa3cb81417538378a30545957"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "chrono",
+ "datafusion",
+ "half",
+ "itertools 0.14.0",
+ "object_store",
+ "pbjson-types",
+ "prost",
+ "substrait",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "deepsize"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +2062,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "earcutr"
@@ -2126,6 +2185,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2958,6 +3018,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,7 +3146,7 @@ dependencies = [
  "jiff",
  "nom 8.0.0",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.1.0",
  "rand 0.9.2",
  "ryu",
  "serde",
@@ -3210,10 +3276,12 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
+ "datafusion",
  "futures",
  "half",
  "lance",
  "lance-core",
+ "lance-datafusion",
  "lance-datagen",
  "lance-file",
  "lance-index",
@@ -3284,6 +3352,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-functions",
  "datafusion-physical-expr",
+ "datafusion-substrait",
  "futures",
  "jsonb",
  "lance-arrow",
@@ -4191,6 +4260,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
@@ -4253,6 +4331,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "futures",
+ "half",
+ "hashbrown 0.16.1",
+ "lz4_flex 0.12.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "object_store",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "tokio",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4268,6 +4383,43 @@ dependencies = [
  "serde_derive",
  "std_prelude",
  "stfu8",
+]
+
+[[package]]
+name = "pbjson"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898bac3fa00d0ba57a4e8289837e965baa2dee8c3749f3b11d45a64b4223d9c3"
+dependencies = [
+ "base64",
+ "serde",
+]
+
+[[package]]
+name = "pbjson-build"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af22d08a625a2213a78dbb0ffa253318c5c79ce3133d32d296655a7bdfb02095"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "pbjson-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e748e28374f10a330ee3bb9f29b828c0ac79831a32bab65015ad9b661ead526"
+dependencies = [
+ "bytes",
+ "chrono",
+ "pbjson",
+ "pbjson-build",
+ "prost",
+ "prost-build",
+ "serde",
 ]
 
 [[package]]
@@ -4826,6 +4978,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "regress"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
 name = "reqsign"
 version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5124,6 +5286,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,6 +5360,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "seq-macro"
@@ -5212,6 +5402,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5236,6 +5437,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_tokenstream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c49585c52c01f13c5c2ebb333f14f6885d76daa768d8a037d28017ec538c69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5245,6 +5458,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5377,6 +5603,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5479,6 +5711,31 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "substrait"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fc4b483a129b9772ccb9c3f7945a472112fdd9140da87f8a4e7f1d44e045d0"
+dependencies = [
+ "heck",
+ "pbjson",
+ "pbjson-build",
+ "pbjson-types",
+ "prettyplease",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "regress",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "syn 2.0.117",
+ "typify",
+ "walkdir",
 ]
 
 [[package]]
@@ -5756,6 +6013,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]
@@ -6047,6 +6315,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "typify"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5bcc6f62eb1fa8aa4098f39b29f93dcb914e17158b76c50360911257aa629"
+dependencies = [
+ "typify-impl",
+ "typify-macro",
+]
+
+[[package]]
+name = "typify-impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1eb359f7ffa4f9ebe947fa11a1b2da054564502968db5f317b7e37693cb2240"
+dependencies = [
+ "heck",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regress",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typify-macro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911c32f3c8514b048c1b228361bebb5e6d73aeec01696e8cc0e82e2ffef8ab7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn 2.0.117",
+ "typify-impl",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6075,6 +6390,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -6826,6 +7147,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.91.0"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-lance = "3.0.1"
+lance = { version = "3.0.1", features = ["substrait"] }
 lance-core = "3.0.1"
 lance-index = "3.0.1"
 lance-io = "3.0.1"
@@ -34,10 +34,12 @@ pin-project = "1.0"
 snafu = "0.9"
 
 [dev-dependencies]
-lance = "3.0.1"
+lance = { version = "3.0.1", features = ["substrait"] }
+lance-datafusion = { version = "3.0.1", features = ["substrait"] }
 lance-datagen = "3.0.1"
 lance-file = "3.0.1"
 lance-table = "3.0.1"
+datafusion = { version = "52.1.0", default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 arrow-array = "57.0.0"
 arrow-schema = "57.0.0"

--- a/include/lance.h
+++ b/include/lance.h
@@ -293,6 +293,29 @@ int32_t lance_scanner_set_fragment_ids(
     size_t len
 );
 
+/**
+ * Set a Substrait filter on the scanner.
+ *
+ * `bytes` must point to a serialized Substrait `ExtendedExpression` message
+ * containing exactly one expression of boolean type. This is the preferred
+ * filter API for query engines that already speak Substrait — it avoids the
+ * round-trip through SQL string formatting and parsing.
+ *
+ * If both this and the SQL filter passed to `lance_scanner_new` are set, the
+ * Substrait filter wins. Calling this with the same scanner more than once
+ * replaces the previously-set Substrait filter. The bytes are copied; the
+ * caller may free them after this call returns.
+ *
+ * @param bytes  Serialized Substrait `ExtendedExpression` bytes (must not be NULL)
+ * @param len    Length of the byte buffer (must be > 0)
+ * @return 0 on success, -1 on error
+ */
+int32_t lance_scanner_set_substrait_filter(
+    LanceScanner* scanner,
+    const uint8_t* bytes,
+    size_t len
+);
+
 /** Close and free a scanner handle. */
 void lance_scanner_close(LanceScanner* scanner);
 

--- a/include/lance.hpp
+++ b/include/lance.hpp
@@ -447,6 +447,19 @@ public:
         return fragment_ids(ids.data(), ids.size());
     }
 
+    /// Set a Substrait filter (serialized ExtendedExpression bytes).
+    /// Wins over any SQL filter passed to the Scanner constructor.
+    Scanner& substrait_filter(const uint8_t* bytes, size_t len) {
+        if (lance_scanner_set_substrait_filter(handle_.get(), bytes, len) != 0)
+            check_error();
+        return *this;
+    }
+
+    /// Set a Substrait filter (vector overload).
+    Scanner& substrait_filter(const std::vector<uint8_t>& bytes) {
+        return substrait_filter(bytes.data(), bytes.size());
+    }
+
     /// Materialize the scan as an ArrowArrayStream (blocking).
     void to_arrow_stream(ArrowArrayStream* out) {
         if (lance_scanner_to_arrow_stream(handle_.get(), out) != 0)

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -42,6 +42,7 @@ pub struct LanceScanner {
     dataset: Arc<Dataset>,
     columns: Option<Vec<String>>,
     filter: Option<String>,
+    substrait_filter: Option<Vec<u8>>,
     limit: Option<i64>,
     offset: Option<i64>,
     batch_size: Option<usize>,
@@ -92,6 +93,7 @@ impl LanceScanner {
             dataset,
             columns: None,
             filter: None,
+            substrait_filter: None,
             limit: None,
             offset: None,
             batch_size: None,
@@ -131,7 +133,10 @@ impl LanceScanner {
         if let Some(cols) = &self.columns {
             scanner.project(cols)?;
         }
-        if let Some(filter) = &self.filter {
+        // Substrait filter takes precedence over SQL filter when both are set.
+        if let Some(bytes) = &self.substrait_filter {
+            scanner.filter_substrait(bytes)?;
+        } else if let Some(filter) = &self.filter {
             scanner.filter(filter)?;
         }
         if self.limit.is_some() || self.offset.is_some() {
@@ -180,7 +185,10 @@ impl LanceScanner {
         if let Some(cols) = &self.columns {
             scanner.project(cols)?;
         }
-        if let Some(filter) = &self.filter {
+        // Substrait filter takes precedence over SQL filter when both are set.
+        if let Some(bytes) = &self.substrait_filter {
+            scanner.filter_substrait(bytes)?;
+        } else if let Some(filter) = &self.filter {
             scanner.filter(filter)?;
         }
         if self.limit.is_some() || self.offset.is_some() {
@@ -345,6 +353,53 @@ pub unsafe extern "C" fn lance_scanner_set_fragment_ids(
         &[]
     };
     s.fragment_ids = Some(id_slice.to_vec());
+    clear_last_error();
+    0
+}
+
+/// Set a Substrait filter on the scanner.
+///
+/// `bytes` must point to a serialized Substrait
+/// [`ExtendedExpression`](https://substrait.io/expressions/extended_expression/)
+/// message containing exactly one expression of boolean type. This is the
+/// preferred filter API for query engines that already speak Substrait — it
+/// avoids the round-trip through SQL string formatting and parsing.
+///
+/// If both this and the SQL filter passed to `lance_scanner_new` are set, the
+/// Substrait filter wins. Calling this with the same scanner more than once
+/// replaces the previously-set Substrait filter.
+///
+/// - `scanner`: An open `LanceScanner*`.
+/// - `bytes`: Pointer to the serialized Substrait `ExtendedExpression` bytes.
+///   Must not be NULL and `len` must be > 0. The bytes are copied into the
+///   scanner; the caller may free them after this call returns.
+/// - `len`: Length of the byte buffer.
+///
+/// Returns 0 on success, -1 on error (check `lance_last_error_*`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn lance_scanner_set_substrait_filter(
+    scanner: *mut LanceScanner,
+    bytes: *const u8,
+    len: usize,
+) -> i32 {
+    if scanner.is_null() {
+        set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
+        return -1;
+    }
+    if bytes.is_null() {
+        set_last_error(LanceErrorCode::InvalidArgument, "bytes is NULL");
+        return -1;
+    }
+    if len == 0 {
+        set_last_error(
+            LanceErrorCode::InvalidArgument,
+            "Substrait filter bytes must be non-empty",
+        );
+        return -1;
+    }
+    let slice = unsafe { std::slice::from_raw_parts(bytes, len) };
+    let s = unsafe { &mut *scanner };
+    s.substrait_filter = Some(slice.to_vec());
     clear_last_error();
     0
 }

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -3608,11 +3608,10 @@ fn test_scanner_with_substrait_filter() {
     let scanner = unsafe { lance_scanner_new(ds, ptr::null(), ptr::null()) };
     assert!(!scanner.is_null());
 
-    let rc = unsafe {
-        lance_scanner_set_substrait_filter(scanner, bytes.as_ptr(), bytes.len())
-    };
+    let rc = unsafe { lance_scanner_set_substrait_filter(scanner, bytes.as_ptr(), bytes.len()) };
     assert_eq!(
-        rc, 0,
+        rc,
+        0,
         "set_substrait_filter should succeed; err: {:?}",
         lance_last_error_code()
     );
@@ -3644,9 +3643,7 @@ fn test_scanner_substrait_filter_overrides_sql_filter() {
 
     // Override with Substrait filter "id > 3" (matches 2 rows).
     let bytes = substrait_id_gt_3();
-    let rc = unsafe {
-        lance_scanner_set_substrait_filter(scanner, bytes.as_ptr(), bytes.len())
-    };
+    let rc = unsafe { lance_scanner_set_substrait_filter(scanner, bytes.as_ptr(), bytes.len()) };
     assert_eq!(rc, 0);
 
     let mut ffi_stream = FFI_ArrowArrayStream::empty();
@@ -3672,21 +3669,16 @@ fn test_scanner_set_substrait_filter_invalid_inputs() {
     let bytes = vec![0u8; 4];
 
     // NULL scanner.
-    let rc = unsafe {
-        lance_scanner_set_substrait_filter(ptr::null_mut(), bytes.as_ptr(), bytes.len())
-    };
+    let rc =
+        unsafe { lance_scanner_set_substrait_filter(ptr::null_mut(), bytes.as_ptr(), bytes.len()) };
     assert_eq!(rc, -1);
 
     // NULL bytes pointer with non-zero len.
-    let rc = unsafe {
-        lance_scanner_set_substrait_filter(scanner, ptr::null(), 4)
-    };
+    let rc = unsafe { lance_scanner_set_substrait_filter(scanner, ptr::null(), 4) };
     assert_eq!(rc, -1);
 
     // Zero len (empty filter) is rejected.
-    let rc = unsafe {
-        lance_scanner_set_substrait_filter(scanner, bytes.as_ptr(), 0)
-    };
+    let rc = unsafe { lance_scanner_set_substrait_filter(scanner, bytes.as_ptr(), 0) };
     assert_eq!(rc, -1);
 
     unsafe { lance_scanner_close(scanner) };

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -3666,7 +3666,7 @@ fn test_scanner_set_substrait_filter_invalid_inputs() {
     let scanner = unsafe { lance_scanner_new(ds, ptr::null(), ptr::null()) };
     assert!(!scanner.is_null());
 
-    let bytes = vec![0u8; 4];
+    let bytes = [0u8; 4];
 
     // NULL scanner.
     let rc =

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -3573,3 +3573,122 @@ fn test_dataset_write_leaves_out_dataset_untouched_on_error() {
         "*out_dataset must be untouched on Lance-level error"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Substrait filter tests
+// ---------------------------------------------------------------------------
+
+/// Build a serialized Substrait `ExtendedExpression` for `id > 3`
+/// against the test dataset's schema (id: Int32, name: Utf8).
+fn substrait_id_gt_3() -> Vec<u8> {
+    use datafusion::logical_expr::{col, lit};
+    use datafusion::prelude::SessionContext;
+    use lance_datafusion::substrait::encode_substrait;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, true),
+    ]));
+    let expr = col("id").gt(lit(3i32));
+    let state = SessionContext::new().state();
+    encode_substrait(expr, schema, &state).unwrap()
+}
+
+#[test]
+fn test_scanner_with_substrait_filter() {
+    let (_tmp, uri) = create_test_dataset();
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let bytes = substrait_id_gt_3();
+    assert!(!bytes.is_empty(), "encoded substrait must be non-empty");
+
+    // Create scanner with no SQL filter, then attach Substrait filter.
+    let scanner = unsafe { lance_scanner_new(ds, ptr::null(), ptr::null()) };
+    assert!(!scanner.is_null());
+
+    let rc = unsafe {
+        lance_scanner_set_substrait_filter(scanner, bytes.as_ptr(), bytes.len())
+    };
+    assert_eq!(
+        rc, 0,
+        "set_substrait_filter should succeed; err: {:?}",
+        lance_last_error_code()
+    );
+
+    let mut ffi_stream = FFI_ArrowArrayStream::empty();
+    let rc = unsafe { lance_scanner_to_arrow_stream(scanner, &mut ffi_stream) };
+    assert_eq!(rc, 0);
+
+    let reader = unsafe { ArrowArrayStreamReader::from_raw(&mut ffi_stream) }.unwrap();
+    let total_rows: usize = reader.map(|r| r.unwrap().num_rows()).sum();
+    assert_eq!(total_rows, 2, "id > 3 should match 2 rows (id=4, id=5)");
+
+    unsafe { lance_scanner_close(scanner) };
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_scanner_substrait_filter_overrides_sql_filter() {
+    // If both SQL and Substrait filters are set, Substrait wins (last write).
+    let (_tmp, uri) = create_test_dataset();
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    // Start with SQL filter "id < 0" (matches 0 rows).
+    let sql = c_str("id < 0");
+    let scanner = unsafe { lance_scanner_new(ds, ptr::null(), sql.as_ptr()) };
+    assert!(!scanner.is_null());
+
+    // Override with Substrait filter "id > 3" (matches 2 rows).
+    let bytes = substrait_id_gt_3();
+    let rc = unsafe {
+        lance_scanner_set_substrait_filter(scanner, bytes.as_ptr(), bytes.len())
+    };
+    assert_eq!(rc, 0);
+
+    let mut ffi_stream = FFI_ArrowArrayStream::empty();
+    let rc = unsafe { lance_scanner_to_arrow_stream(scanner, &mut ffi_stream) };
+    assert_eq!(rc, 0);
+
+    let reader = unsafe { ArrowArrayStreamReader::from_raw(&mut ffi_stream) }.unwrap();
+    let total_rows: usize = reader.map(|r| r.unwrap().num_rows()).sum();
+    assert_eq!(total_rows, 2, "Substrait filter should override SQL filter");
+
+    unsafe { lance_scanner_close(scanner) };
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_scanner_set_substrait_filter_invalid_inputs() {
+    let (_tmp, uri) = create_test_dataset();
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    let scanner = unsafe { lance_scanner_new(ds, ptr::null(), ptr::null()) };
+    assert!(!scanner.is_null());
+
+    let bytes = vec![0u8; 4];
+
+    // NULL scanner.
+    let rc = unsafe {
+        lance_scanner_set_substrait_filter(ptr::null_mut(), bytes.as_ptr(), bytes.len())
+    };
+    assert_eq!(rc, -1);
+
+    // NULL bytes pointer with non-zero len.
+    let rc = unsafe {
+        lance_scanner_set_substrait_filter(scanner, ptr::null(), 4)
+    };
+    assert_eq!(rc, -1);
+
+    // Zero len (empty filter) is rejected.
+    let rc = unsafe {
+        lance_scanner_set_substrait_filter(scanner, bytes.as_ptr(), 0)
+    };
+    assert_eq!(rc, -1);
+
+    unsafe { lance_scanner_close(scanner) };
+    unsafe { lance_dataset_close(ds) };
+}


### PR DESCRIPTION
## Summary

Adds a new C entry point that accepts a serialized Substrait `ExtendedExpression` as the scan filter, alongside the existing SQL-string filter passed to `lance_scanner_new`. Engines that already speak Substrait (e.g. Velox, DataFusion-based pipelines) can now push pre-built filter expressions into Lance without round-tripping through SQL formatting and parsing.

## Motivation

We're integrating Lance as a file-format reader into Velox/Bolt, which represents filter expressions natively and can serialize them to Substrait via its `BoltToSubstraitExpr` converter. The current SQL-string filter forces an unnecessary serialization → re-parse step, and many expressions (e.g. expressions over types Lance can't yet print as SQL) round-trip poorly. A Substrait byte-buffer entry point matches what Lance's Rust `Scanner::filter_substrait()` already accepts.

## API

```c
/**
 * Set a Substrait filter on the scanner.
 *
 * `bytes` must point to a serialized Substrait `ExtendedExpression` message
 * containing exactly one expression of boolean type. ...
 *
 * If both this and the SQL filter passed to `lance_scanner_new` are set, the
 * Substrait filter wins. ... The bytes are copied; the caller may free them
 * after this call returns.
 *
 * @return 0 on success, -1 on error
 */
int32_t lance_scanner_set_substrait_filter(
    LanceScanner* scanner,
    const uint8_t* bytes,
    size_t len
);
```

C++ RAII wrapper:

```cpp
scanner.substrait_filter(bytes, len);          // raw pointer + len
scanner.substrait_filter(std::vector<uint8_t>{...});  // vector overload
```

## Implementation notes

- Adds a `substrait_filter: Option<Vec<u8>>` field to the internal `LanceScanner` and routes it to `Scanner::filter_substrait()` in both `materialize_stream` and `build_scanner`.
- If both an SQL filter (from `lance_scanner_new`) and a Substrait filter are set, the Substrait filter takes precedence — matches the typical "set it last to override" intuition for Substrait callers.
- Enables `features = ["substrait"]` on the `lance` dependency so the underlying API is available.

## Tests

Three new tests in `tests/c_api_test.rs`:

- `test_scanner_with_substrait_filter` — happy path; encodes `id > 3` via `lance_datafusion::substrait::encode_substrait`, asserts the scan returns 2 rows.
- `test_scanner_substrait_filter_overrides_sql_filter` — SQL filter `id < 0` (matches 0) is overridden by Substrait filter `id > 3` (matches 2).
- `test_scanner_set_substrait_filter_invalid_inputs` — NULL scanner, NULL bytes, and zero `len` all return -1.

`lance-datafusion` (with the `substrait` feature) and `datafusion` are added as dev-dependencies for test-only Substrait encoding.

## Test plan

- [x] `cargo test --test c_api_test` — 95 passed, 0 failed (3 new + 92 existing)
- [x] `cargo test --test compile_and_run_test -- --ignored` — both C and C++ compile/link tests pass
- [x] `cargo build --release` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)