### PR TITLE
docs: sync README roadmap with shipped APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 The C/C++ binding to [Lance](https://github.com/lancedb/lance), providing native access to the Lance columnar format via a stable C ABI and header-only C++ RAII wrappers.
 
-- **C header:** [`include/lance.h`](include/lance.h)
-- **C++ wrappers:** [`include/lance.hpp`](include/lance.hpp) (header-only, RAII, exceptions)
+- **C header:** [`include/lance/lance.h`](include/lance/lance.h)
+- **C++ wrappers:** [`include/lance/lance.hpp`](include/lance/lance.hpp) (header-only, RAII, exceptions)
 - **Data exchange:** [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html) for zero-copy interop
 
 ## Roadmap
@@ -42,13 +42,13 @@ Based on the [liblance RFC](https://github.com/lance-format/lance/discussions/60
 
 | Status | Component | Description |
 |--------|-----------|-------------|
-| [ ] | Dataset write | Create / append / overwrite from ArrowArrayStream |
+| [x] | Dataset write | Create / append / overwrite from ArrowArrayStream via `lance_dataset_write()`; tunable variant `lance_dataset_write_with_params()` for file/row-group sizing, Lance format version, and stable row IDs |
 | [x] | Fragment writer | Batch-at-a-time fragment file writing (no commit) via `lance_write_fragments()` |
 | [ ] | Delete operations | Predicate-based deletion |
 | [ ] | Update operations | Expression-based row updates |
 | [ ] | Merge-insert | Upsert functionality with builder pattern |
 | [ ] | Schema evolution | Add/drop/alter columns with expressions |
-| [ ] | Version management | Checkout, restore, list version operations |
+| [x] | Version management | List via `lance_dataset_versions()`, rollback via `lance_dataset_restore()`, checkout via `lance_dataset_open(uri, opts, version)` |
 
 ### Phase 4: Advanced Features
 
@@ -66,6 +66,7 @@ Based on the [liblance RFC](https://github.com/lance-format/lance/discussions/60
 |--------|-----------|-------------|
 | [x] | Async scan | Callback-based `lance_scanner_scan_async()` for non-blocking scans |
 | [x] | Dataset metadata | `lance_dataset_version()`, `lance_dataset_count_rows()`, `lance_dataset_latest_version()` |
+| [x] | Substrait filter pushdown | `lance_scanner_set_substrait_filter()` accepts a serialized Substrait `ExtendedExpression` (preferred over SQL strings for query engines) |
 
 ## Building
 


### PR DESCRIPTION
## Summary

Bring the README roadmap in line with what actually shipped on `main`:

- Fix the **header path links** at the top — `include/lance.h` / `include/lance.hpp` 404'd after #26 (Phase 4 packaging) moved the headers under `include/lance/`.
- **Phase 3 → Dataset write**: flip `[ ]` → `[x]` (`lance_dataset_write` from #16, `lance_dataset_write_with_params` from #20).
- **Phase 3 → Version management**: flip `[ ]` → `[x]` — list (`lance_dataset_versions`, #18), rollback (`lance_dataset_restore`, #18), and version checkout (`lance_dataset_open(uri, opts, version)`, documented in #19).
- **Additional features**: add `Substrait filter pushdown` row pointing at `lance_scanner_set_substrait_filter` (#25).

No source changes; docs only.

## Test plan

- [x] Markdown renders correctly (links resolve to `include/lance/lance.h` and `include/lance/lance.hpp`)
- [x] `git diff origin/main` shows only the four targeted edits