### PR TITLE
feat: add lance_dataset_delete for predicate-based row deletion

### DIFF
--- a/include/lance/lance.h
+++ b/include/lance/lance.h
@@ -222,6 +222,32 @@ void lance_versions_close(LanceVersions* versions);
 LanceDataset* lance_dataset_restore(const LanceDataset* dataset, uint64_t version);
 
 /**
+ * Delete rows matching the SQL `predicate`, committing a new manifest.
+ *
+ * Mutates `dataset` in place — the same handle remains valid afterward and
+ * sees the new version. Scanners already in flight against this dataset
+ * keep their pre-delete snapshot view.
+ *
+ * @param dataset          Open dataset (not consumed). Must not be NULL.
+ * @param predicate        SQL filter, e.g. "id > 100" or "name = 'alice'".
+ *                         Must not be NULL or empty.
+ * @param out_num_deleted  Optional. If non-NULL, on success receives the
+ *                         number of rows that were deleted (0 if the
+ *                         predicate matched nothing). On error the slot is
+ *                         left unchanged — do not read it.
+ * @return 0 on success, -1 on error. Error codes:
+ *         LANCE_ERR_INVALID_ARGUMENT for NULL/empty args (validated at this
+ *         boundary), LANCE_ERR_INTERNAL for malformed SQL or unknown columns
+ *         (surfaced from the upstream parser), and LANCE_ERR_COMMIT_CONFLICT
+ *         for a concurrent writer.
+ */
+int32_t lance_dataset_delete(
+    LanceDataset* dataset,
+    const char* predicate,
+    uint64_t* out_num_deleted
+);
+
+/**
  * Export the dataset schema via Arrow C Data Interface.
  * @param out  Pointer to caller-allocated ArrowSchema struct
  * @return 0 on success, -1 on error

--- a/include/lance/lance.hpp
+++ b/include/lance/lance.hpp
@@ -295,6 +295,21 @@ public:
         return Dataset(out);
     }
 
+    /// Delete rows matching the SQL `predicate`, committing a new manifest.
+    /// Mutates this dataset in place; the handle continues to point at the
+    /// new version. Returns the number of rows that were deleted.
+    /// Throws lance::Error on failure (empty predicate, malformed SQL,
+    /// commit conflict, ...).
+    ///
+    /// Named `delete_rows` to avoid the C++ `delete` keyword.
+    uint64_t delete_rows(const std::string& predicate) {
+        uint64_t num_deleted = 0;
+        if (lance_dataset_delete(handle_.get(), predicate.c_str(), &num_deleted) != 0) {
+            check_error();
+        }
+        return num_deleted;
+    }
+
     /// Export the schema as an Arrow C Data Interface struct.
     void schema(ArrowSchema* out) const {
         if (lance_dataset_schema(handle_.get(), out) != 0) {

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Delete C API: drop rows matching an SQL predicate, committing a new manifest.
+//!
+//! Mutates the dataset in place under an exclusive write lock; existing
+//! scanners that already cloned the inner Arc keep their snapshot view.
+
+use std::ffi::c_char;
+
+use lance_core::Result;
+
+use crate::dataset::LanceDataset;
+use crate::error::ffi_try;
+use crate::helpers;
+use crate::runtime::block_on;
+
+/// Delete rows matching the SQL `predicate`, committing a new manifest.
+///
+/// - `dataset`: Open dataset (mutated; same handle remains valid afterward).
+///   Must not be NULL.
+/// - `predicate`: SQL filter expression, e.g. `"id > 100"` or `"name = 'a'"`.
+///   Must not be NULL or empty.
+/// - `out_num_deleted`: Optional. If non-NULL, receives the number of rows
+///   that were deleted (0 if the predicate matched nothing). On error the
+///   slot is untouched.
+///
+/// Returns 0 on success, -1 on error. Error codes:
+/// `LANCE_ERR_INVALID_ARGUMENT` for NULL/empty args (validated at this
+/// boundary), `LANCE_ERR_INTERNAL` for malformed SQL or unknown columns
+/// (surfaced from the upstream parser), and `LANCE_ERR_COMMIT_CONFLICT`
+/// for a concurrent writer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn lance_dataset_delete(
+    dataset: *mut LanceDataset,
+    predicate: *const c_char,
+    out_num_deleted: *mut u64,
+) -> i32 {
+    ffi_try!(
+        unsafe { delete_inner(dataset, predicate, out_num_deleted) },
+        neg
+    )
+}
+
+unsafe fn delete_inner(
+    dataset: *mut LanceDataset,
+    predicate: *const c_char,
+    out_num_deleted: *mut u64,
+) -> Result<i32> {
+    if dataset.is_null() || predicate.is_null() {
+        return Err(lance_core::Error::InvalidInput {
+            source: "dataset and predicate must not be NULL".into(),
+            location: snafu::location!(),
+        });
+    }
+
+    // SAFETY: `predicate` is non-NULL (checked above) and the caller
+    // guarantees it points to a NUL-terminated C string valid for the
+    // duration of this call. `parse_c_string` reads by shared reference.
+    let predicate_str = unsafe { helpers::parse_c_string(predicate)? }
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| lance_core::Error::InvalidInput {
+            // NULL is rejected above; only the empty case reaches here.
+            source: "predicate must not be empty".into(),
+            location: snafu::location!(),
+        })?;
+
+    // SAFETY: `dataset` is non-NULL (checked above) and the caller guarantees
+    // it points to a live `LanceDataset` not aliased mutably elsewhere.
+    let ds = unsafe { &*dataset };
+    let result = ds.with_mut(|d| block_on(d.delete(predicate_str)))?;
+
+    if !out_num_deleted.is_null() {
+        // SAFETY: caller guarantees `out_num_deleted` (when non-NULL) points
+        // to caller-owned, writable storage of size `sizeof(uint64_t)`. We
+        // only write on success; on the error paths above the slot stays
+        // untouched per the documented contract.
+        unsafe { *out_num_deleted = result.num_deleted_rows };
+    }
+    Ok(0)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 mod async_dispatcher;
 mod batch;
 mod dataset;
+mod delete;
 mod error;
 mod fragment_writer;
 mod helpers;
@@ -31,6 +32,7 @@ mod writer;
 // Re-export all extern "C" symbols so they appear in the cdylib.
 pub use batch::*;
 pub use dataset::*;
+pub use delete::*;
 pub use error::{
     LanceErrorCode, lance_free_string, lance_last_error_code, lance_last_error_message,
 };

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -3684,3 +3684,191 @@ fn test_scanner_set_substrait_filter_invalid_inputs() {
     unsafe { lance_scanner_close(scanner) };
     unsafe { lance_dataset_close(ds) };
 }
+
+// ===========================================================================
+// lance_dataset_delete
+// ===========================================================================
+
+#[test]
+fn test_delete_basic_predicate() {
+    let (_tmp, uri) = create_large_dataset(100);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let pred = c_str("id >= 50");
+    let mut num_deleted: u64 = 0;
+    let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), &mut num_deleted) };
+    assert_eq!(rc, 0);
+    assert_eq!(num_deleted, 50);
+
+    // Existing handle now sees the post-delete dataset.
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 50);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_delete_all_rows() {
+    let (_tmp, uri) = create_large_dataset(20);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let pred = c_str("true");
+    let mut num_deleted: u64 = 0;
+    let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), &mut num_deleted) };
+    assert_eq!(rc, 0);
+    assert_eq!(num_deleted, 20);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 0);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_delete_no_match_returns_zero() {
+    let (_tmp, uri) = create_large_dataset(10);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let pred = c_str("id > 9999");
+    let mut num_deleted: u64 = 0;
+    let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), &mut num_deleted) };
+    assert_eq!(rc, 0);
+    assert_eq!(num_deleted, 0);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 10);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_delete_out_param_optional() {
+    let (_tmp, uri) = create_large_dataset(10);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let pred = c_str("id < 3");
+    // Pass NULL out_num_deleted — must succeed without writing anything.
+    let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), ptr::null_mut()) };
+    assert_eq!(rc, 0);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 7);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_delete_bumps_version() {
+    let (_tmp, uri) = create_large_dataset(5);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let v_before = unsafe { lance_dataset_version(ds) };
+    let pred = c_str("id = 0");
+    let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), ptr::null_mut()) };
+    assert_eq!(rc, 0);
+    let v_after = unsafe { lance_dataset_version(ds) };
+    assert!(
+        v_after > v_before,
+        "version should increase: before={v_before}, after={v_after}"
+    );
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_delete_null_dataset_rejected() {
+    let pred = c_str("id > 0");
+    let rc = unsafe { lance_dataset_delete(ptr::null_mut(), pred.as_ptr(), ptr::null_mut()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+}
+
+// Locks in the documented contract: when the call fails, `out_num_deleted`
+// must be left unchanged. A future refactor that pre-zeroes the slot before
+// validating inputs would silently break this guarantee.
+#[test]
+fn test_delete_out_param_untouched_on_error() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let mut sentinel: u64 = 0xDEAD_BEEF;
+    // Empty predicate → INVALID_ARGUMENT before any work happens.
+    let pred = c_str("");
+    let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), &mut sentinel) };
+    assert_eq!(rc, -1);
+    assert_eq!(sentinel, 0xDEAD_BEEF, "out slot must be untouched on error");
+
+    // Same property must hold for upstream-surfaced errors (malformed SQL).
+    let pred = c_str("not a real predicate ((((");
+    let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), &mut sentinel) };
+    assert_eq!(rc, -1);
+    assert_eq!(sentinel, 0xDEAD_BEEF, "out slot must be untouched on error");
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_delete_null_predicate_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let rc = unsafe { lance_dataset_delete(ds, ptr::null(), ptr::null_mut()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+    // Dataset is unchanged.
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_delete_empty_predicate_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let pred = c_str("");
+    let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), ptr::null_mut()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_delete_invalid_predicate_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    // Garbage SQL — Lance / DataFusion should reject this at parse time.
+    let pred = c_str("not a real predicate ((((");
+    let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), ptr::null_mut()) };
+    assert_eq!(rc, -1);
+    // Parser errors come back as Internal (this is what upstream surfaces;
+    // we don't try to re-classify them at the FFI boundary). If upstream
+    // ever tightens this to InvalidArgument, tighten this assertion too.
+    assert_eq!(lance_last_error_code(), LanceErrorCode::Internal);
+    // The dataset is left untouched on the error path.
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_delete_unknown_column_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let pred = c_str("no_such_column = 1");
+    let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), ptr::null_mut()) };
+    assert_eq!(rc, -1);
+    // Same upstream classification as malformed SQL — see note above.
+    assert_eq!(lance_last_error_code(), LanceErrorCode::Internal);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
+
+    unsafe { lance_dataset_close(ds) };
+}

--- a/tests/cpp/test_c_api.c
+++ b/tests/cpp/test_c_api.c
@@ -268,6 +268,35 @@ static void test_dataset_write_roundtrip(const char *src_uri, const char *dst_ur
     printf("OK\n");
 }
 
+/* Re-opens the dataset just written by `test_dataset_write_roundtrip` and
+ * exercises `lance_dataset_delete`. Must run after the write roundtrip. */
+static void test_delete(const char *write_uri) {
+    printf("  test_delete... ");
+
+    LanceDataset *ds = lance_dataset_open(write_uri, NULL, 0);
+    ASSERT(ds != NULL, "open failed");
+
+    uint64_t before = lance_dataset_count_rows(ds);
+    CHECK_OK();
+    ASSERT(before > 0, "fixture expected to have rows");
+
+    /* Match-everything predicate; deleted count must equal `before`. */
+    uint64_t deleted = 0;
+    int32_t rc = lance_dataset_delete(ds, "true", &deleted);
+    ASSERT(rc == 0, "delete failed");
+    ASSERT(deleted == before, "deleted count mismatch");
+    ASSERT(lance_dataset_count_rows(ds) == 0, "expected zero rows after delete");
+
+    /* NULL predicate must be rejected with INVALID_ARGUMENT. */
+    rc = lance_dataset_delete(ds, NULL, NULL);
+    ASSERT(rc == -1, "NULL predicate must fail");
+    ASSERT(lance_last_error_code() == LANCE_ERR_INVALID_ARGUMENT,
+           "expected INVALID_ARGUMENT");
+
+    lance_dataset_close(ds);
+    printf("deleted=%llu... OK\n", (unsigned long long)deleted);
+}
+
 int main(int argc, char **argv) {
     if (argc < 3) {
         fprintf(stderr, "Usage: %s <dataset_uri> <write_uri>\n", argv[0]);
@@ -285,6 +314,7 @@ int main(int argc, char **argv) {
     test_restore_to_current(uri);
     test_error_handling();
     test_dataset_write_roundtrip(uri, write_uri);
+    test_delete(write_uri);
 
     printf("All C tests passed!\n");
     return 0;

--- a/tests/cpp/test_cpp_api.cpp
+++ b/tests/cpp/test_cpp_api.cpp
@@ -302,6 +302,34 @@ static void test_dataset_write_roundtrip(const std::string& src_uri,
     PASS();
 }
 
+// Re-opens the dataset just written by `test_dataset_write_roundtrip` and
+// exercises `Dataset::delete_rows`. Must run after the write roundtrip.
+static void test_delete_rows(const std::string& dst_uri) {
+    TEST(test_delete_rows);
+
+    auto ds = lance::Dataset::open(dst_uri);
+    uint64_t before = ds.count_rows();
+    assert(before > 0 && "test fixture expected to have rows");
+
+    // Predicate that matches everything — exact deleted count == before.
+    uint64_t deleted = ds.delete_rows("true");
+    assert(deleted == before);
+    assert(ds.count_rows() == 0);
+
+    // Empty predicate must throw.
+    bool caught_empty = false;
+    try {
+        ds.delete_rows("");
+    } catch (const lance::Error& e) {
+        caught_empty = true;
+        assert(e.code == LANCE_ERR_INVALID_ARGUMENT);
+    }
+    assert(caught_empty);
+
+    printf("deleted=%llu... ", (unsigned long long)deleted);
+    PASS();
+}
+
 int main(int argc, char** argv) {
     if (argc < 3) {
         fprintf(stderr, "Usage: %s <dataset_uri> <write_uri>\n", argv[0]);
@@ -324,6 +352,7 @@ int main(int argc, char** argv) {
     test_nearest_smoke(uri);
     test_fts_smoke(uri);
     test_dataset_write_roundtrip(uri, write_uri);
+    test_delete_rows(write_uri);
 
     printf("All C++ tests passed!\n");
     return 0;


### PR DESCRIPTION
## Summary

- Adds `lance_dataset_delete(LanceDataset*, predicate, *out_num_deleted)` — drops rows matching an SQL predicate, committing a new manifest. Mutates the handle in place via the existing `with_mut` path; in-flight scanners keep their pre-delete snapshot.
- Adds `lance::Dataset::delete_rows(const std::string&) -> uint64_t` C++ wrapper (renamed because `delete` is a C++ keyword); throws `lance::Error` on failure.
- Surfaces the deleted row count via an optional out param. NULL is accepted to discard.

Closes #30.

## Error semantics

| Code | When |
|---|---|
| `LANCE_ERR_INVALID_ARGUMENT` | NULL dataset, NULL predicate, or empty predicate (validated at the FFI boundary). |
| `LANCE_ERR_INTERNAL` | Malformed SQL or unknown column (surfaced from the upstream parser; not re-classified at the FFI boundary). |
| `LANCE_ERR_COMMIT_CONFLICT` | Concurrent writer landed a manifest first. |

The doc deliberately calls out that we don't re-classify upstream parser errors — if upstream tightens its error taxonomy, we tighten the assertion. The two relevant tests assert the exact code so a future upstream change is caught.

## Design notes

- `out_num_deleted` is documented as **untouched on error** (every error path returns before writing it). `test_delete_out_param_untouched_on_error` locks this in with a `0xDEAD_BEEF` sentinel against both the boundary-validated path (empty predicate) and an upstream-surfaced path (malformed SQL).
- The C++ wrapper takes `const std::string&` (not `string_view`) since the underlying C API needs NUL-termination.
- Mirrors `lance_dataset_drop_index` / `lance_dataset_restore` patterns: `unsafe fn`, `ffi_try!`, `with_mut(|d| block_on(d.delete(...)))`. SAFETY comments on every new unsafe block.

## Test plan

- `cargo test` — **106 passed**, 0 failed. 11 new tests:
  - `test_delete_basic_predicate` — `id >= 50` on 100-row dataset → 50 deleted.
  - `test_delete_all_rows` — `\"true\"` → all rows deleted.
  - `test_delete_no_match_returns_zero` — predicate matches nothing → count = 0, dataset unchanged.
  - `test_delete_out_param_optional` — NULL `out_num_deleted` succeeds.
  - `test_delete_out_param_untouched_on_error` — sentinel preserved on every error path.
  - `test_delete_bumps_version` — version strictly increases on success.
  - `test_delete_null_dataset_rejected` — `LANCE_ERR_INVALID_ARGUMENT`.
  - `test_delete_null_predicate_rejected` — `LANCE_ERR_INVALID_ARGUMENT`, dataset unchanged.
  - `test_delete_empty_predicate_rejected` — `LANCE_ERR_INVALID_ARGUMENT`, dataset unchanged.
  - `test_delete_invalid_predicate_rejected` — `LANCE_ERR_INTERNAL`, dataset unchanged.
  - `test_delete_unknown_column_rejected` — `LANCE_ERR_INTERNAL`, dataset unchanged.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps` clean.
- `cargo test --test compile_and_run_test -- --ignored` — C and C++ integration tests pass; both exercise the new wrapper end-to-end (delete-everything against the write-roundtrip dataset, plus an empty/NULL predicate rejection).

## Out of scope

`lance_dataset_update` and `lance_dataset_merge_insert` will land as follow-on PRs; they share the predicate-driven mutation pattern and will reuse the same SAFETY / `with_mut` plumbing.