### PR TITLE
feat: add lance_dataset_update for predicate + expression-based row updates

### DIFF
--- a/include/lance/lance.h
+++ b/include/lance/lance.h
@@ -248,6 +248,43 @@ int32_t lance_dataset_delete(
 );
 
 /**
+ * Update rows matching the SQL `predicate` by applying per-column SQL
+ * expressions, committing a new manifest.
+ *
+ * Mutates `dataset` in place — the same handle remains valid afterward and
+ * sees the new version. Scanners already in flight against this dataset
+ * keep their pre-update snapshot view.
+ *
+ * @param dataset          Open dataset (not consumed). Must not be NULL.
+ * @param predicate        SQL filter, e.g. "id > 100". Pass NULL to update
+ *                         every row. An explicit empty string is rejected.
+ * @param columns          Column names to update. Length = `num_updates`.
+ *                         Must not be NULL when `num_updates > 0`; each
+ *                         entry must be a non-NULL, non-empty C string.
+ * @param values           SQL scalar expressions, evaluated per row, one
+ *                         per `columns[i]` (e.g. `"100"`, `"price * 2"`,
+ *                         `"CASE WHEN ... END"`). Same NULL/length rules.
+ * @param num_updates      Length of `columns` and `values`. Must be >= 1.
+ * @param out_num_updated  Optional. If non-NULL, on success receives the
+ *                         number of rows that were updated (0 if the
+ *                         predicate matched nothing). On error the slot is
+ *                         left unchanged — do not read it.
+ * @return 0 on success, -1 on error. Error codes:
+ *         LANCE_ERR_INVALID_ARGUMENT for NULL/empty args, `num_updates == 0`,
+ *         malformed SQL, and unknown columns (the upstream UpdateBuilder
+ *         wraps parser errors as invalid-input); LANCE_ERR_COMMIT_CONFLICT
+ *         for a concurrent writer.
+ */
+int32_t lance_dataset_update(
+    LanceDataset* dataset,
+    const char* predicate,
+    const char* const* columns,
+    const char* const* values,
+    size_t num_updates,
+    uint64_t* out_num_updated
+);
+
+/**
  * Export the dataset schema via Arrow C Data Interface.
  * @param out  Pointer to caller-allocated ArrowSchema struct
  * @return 0 on success, -1 on error

--- a/include/lance/lance.h
+++ b/include/lance/lance.h
@@ -271,9 +271,8 @@ int32_t lance_dataset_delete(
  *                         left unchanged — do not read it.
  * @return 0 on success, -1 on error. Error codes:
  *         LANCE_ERR_INVALID_ARGUMENT for NULL/empty args, `num_updates == 0`,
- *         malformed SQL, and unknown columns (the upstream UpdateBuilder
- *         wraps parser errors as invalid-input); LANCE_ERR_COMMIT_CONFLICT
- *         for a concurrent writer.
+ *         malformed SQL, and unknown columns; LANCE_ERR_COMMIT_CONFLICT for
+ *         a concurrent writer.
  */
 int32_t lance_dataset_update(
     LanceDataset* dataset,

--- a/include/lance/lance.hpp
+++ b/include/lance/lance.hpp
@@ -348,6 +348,39 @@ public:
         return num_deleted;
     }
 
+    /// Update rows matching the SQL `predicate` by applying per-column SQL
+    /// expressions. Mutates this dataset in place; the handle continues to
+    /// point at the new version. Returns the number of rows updated.
+    ///
+    /// `predicate` is empty -> updates every row (passed as NULL to the C
+    /// API). `updates` must be non-empty; each pair is `{column_name,
+    /// sql_expr}`. Throws lance::Error on failure (empty pair entry,
+    /// malformed SQL, unknown column, commit conflict, ...).
+    uint64_t update(
+        const std::string& predicate,
+        const std::vector<std::pair<std::string, std::string>>& updates) {
+        std::vector<const char*> col_ptrs;
+        std::vector<const char*> val_ptrs;
+        col_ptrs.reserve(updates.size());
+        val_ptrs.reserve(updates.size());
+        for (const auto& [col, val] : updates) {
+            col_ptrs.push_back(col.c_str());
+            val_ptrs.push_back(val.c_str());
+        }
+        uint64_t num_updated = 0;
+        const char* pred_ptr = predicate.empty() ? nullptr : predicate.c_str();
+        if (lance_dataset_update(
+                handle_.get(),
+                pred_ptr,
+                col_ptrs.data(),
+                val_ptrs.data(),
+                updates.size(),
+                &num_updated) != 0) {
+            check_error();
+        }
+        return num_updated;
+    }
+
     /// Export the schema as an Arrow C Data Interface struct.
     void schema(ArrowSchema* out) const {
         if (lance_dataset_schema(handle_.get(), out) != 0) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ mod index;
 mod restore;
 pub mod runtime;
 mod scanner;
+mod update;
 mod versions;
 mod writer;
 
@@ -40,5 +41,6 @@ pub use fragment_writer::*;
 pub use index::*;
 pub use restore::*;
 pub use scanner::*;
+pub use update::*;
 pub use versions::*;
 pub use writer::*;

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Update C API: rewrite columns of rows matching an SQL predicate by
+//! evaluating per-column SQL expressions, committing a new manifest.
+//!
+//! Mutates the dataset in place under an exclusive write lock; existing
+//! scanners that already cloned the inner Arc keep their snapshot view.
+
+use std::ffi::c_char;
+use std::sync::Arc;
+
+use lance::dataset::UpdateBuilder;
+use lance_core::Result;
+
+use crate::dataset::LanceDataset;
+use crate::error::ffi_try;
+use crate::helpers;
+use crate::runtime::block_on;
+
+/// Update rows matching the SQL `predicate` by applying per-column SQL
+/// expressions, committing a new manifest.
+///
+/// - `dataset`: Open dataset (mutated; same handle remains valid afterward).
+///   Must not be NULL.
+/// - `predicate`: SQL filter expression, or NULL to update every row. When
+///   non-NULL it must not be empty.
+/// - `columns` / `values`: Parallel arrays of length `num_updates`. Each
+///   `values[i]` is an SQL scalar expression evaluated per row (literals,
+///   column references, arithmetic, `CASE`, ...). Both arrays must be
+///   non-NULL when `num_updates > 0`, and every entry must itself be a
+///   non-NULL, non-empty C string.
+/// - `num_updates`: Length of `columns` and `values`. Must be `>= 1`.
+/// - `out_num_updated`: Optional. If non-NULL, receives the number of rows
+///   that were updated (0 if `predicate` matched nothing). On error the
+///   slot is untouched.
+///
+/// Returns 0 on success, -1 on error. Error codes:
+/// `LANCE_ERR_INVALID_ARGUMENT` for NULL/empty args, `num_updates == 0`,
+/// malformed SQL, and unknown columns (the upstream `UpdateBuilder` wraps
+/// parser errors as invalid-input); `LANCE_ERR_COMMIT_CONFLICT` for a
+/// concurrent writer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn lance_dataset_update(
+    dataset: *mut LanceDataset,
+    predicate: *const c_char,
+    columns: *const *const c_char,
+    values: *const *const c_char,
+    num_updates: usize,
+    out_num_updated: *mut u64,
+) -> i32 {
+    ffi_try!(
+        unsafe {
+            update_inner(
+                dataset,
+                predicate,
+                columns,
+                values,
+                num_updates,
+                out_num_updated,
+            )
+        },
+        neg
+    )
+}
+
+unsafe fn update_inner(
+    dataset: *mut LanceDataset,
+    predicate: *const c_char,
+    columns: *const *const c_char,
+    values: *const *const c_char,
+    num_updates: usize,
+    out_num_updated: *mut u64,
+) -> Result<i32> {
+    if dataset.is_null() {
+        return Err(lance_core::Error::InvalidInput {
+            source: "dataset must not be NULL".into(),
+            location: snafu::location!(),
+        });
+    }
+    if num_updates == 0 {
+        return Err(lance_core::Error::InvalidInput {
+            source: "num_updates must be >= 1".into(),
+            location: snafu::location!(),
+        });
+    }
+    if columns.is_null() || values.is_null() {
+        return Err(lance_core::Error::InvalidInput {
+            source: "columns and values must not be NULL when num_updates > 0".into(),
+            location: snafu::location!(),
+        });
+    }
+
+    // Optional predicate. NULL means "update every row"; an explicit empty
+    // string is rejected so callers can't slip a no-op past validation.
+    // SAFETY: when non-NULL the caller guarantees `predicate` points to a
+    // NUL-terminated C string valid for this call. `parse_c_string` reads
+    // by shared reference.
+    let predicate_str = unsafe { helpers::parse_c_string(predicate)? };
+    if let Some(p) = predicate_str.as_ref()
+        && p.is_empty()
+    {
+        return Err(lance_core::Error::InvalidInput {
+            source: "predicate must not be empty (pass NULL to update all rows)".into(),
+            location: snafu::location!(),
+        });
+    }
+
+    // Collect (column, value) pairs into owned strings up front so we can
+    // surface a precise per-index error on bad input before touching the
+    // write lock.
+    let mut update_pairs: Vec<(String, String)> = Vec::with_capacity(num_updates);
+    for i in 0..num_updates {
+        // SAFETY: `columns` and `values` are non-NULL (checked above) and the
+        // caller guarantees both arrays have at least `num_updates` entries.
+        let col_ptr = unsafe { *columns.add(i) };
+        let val_ptr = unsafe { *values.add(i) };
+        // SAFETY: see the guarantee on `predicate` above; the same applies
+        // to each entry pointer within the arrays.
+        let col = unsafe { helpers::parse_c_string(col_ptr)? }
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| lance_core::Error::InvalidInput {
+                source: format!("columns[{i}] must not be NULL or empty").into(),
+                location: snafu::location!(),
+            })?;
+        let val = unsafe { helpers::parse_c_string(val_ptr)? }
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| lance_core::Error::InvalidInput {
+                source: format!("values[{i}] must not be NULL or empty").into(),
+                location: snafu::location!(),
+            })?;
+        update_pairs.push((col.to_string(), val.to_string()));
+    }
+
+    // SAFETY: `dataset` is non-NULL (checked above) and the caller guarantees
+    // it points to a live `LanceDataset` not aliased mutably elsewhere.
+    let ds = unsafe { &*dataset };
+    let rows_updated = ds.with_mut(|d| {
+        block_on(async {
+            // Upstream `UpdateBuilder::new` takes `Arc<Dataset>` (it works
+            // off a snapshot rather than `&mut Dataset`). Mirror what
+            // `Dataset::delete` does internally: clone the snapshot for the
+            // builder, then publish `result.new_dataset` into our handle so
+            // subsequent calls observe the new version.
+            let snapshot = Arc::new(d.clone());
+            let mut builder = UpdateBuilder::new(snapshot);
+            if let Some(p) = predicate_str {
+                builder = builder.update_where(p)?;
+            }
+            for (col, val) in &update_pairs {
+                builder = builder.set(col, val)?;
+            }
+            let result = builder.build()?.execute().await?;
+            *d = Arc::try_unwrap(result.new_dataset.clone()).unwrap_or_else(|arc| (*arc).clone());
+            Ok::<u64, lance_core::Error>(result.rows_updated)
+        })
+    })?;
+
+    if !out_num_updated.is_null() {
+        // SAFETY: caller guarantees `out_num_updated` (when non-NULL) points
+        // to caller-owned, writable storage of size `sizeof(uint64_t)`. We
+        // only write on success; on the error paths above the slot stays
+        // untouched per the documented contract.
+        unsafe { *out_num_updated = rows_updated };
+    }
+    Ok(0)
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -37,8 +37,7 @@ use crate::runtime::block_on;
 ///
 /// Returns 0 on success, -1 on error. Error codes:
 /// `LANCE_ERR_INVALID_ARGUMENT` for NULL/empty args, `num_updates == 0`,
-/// malformed SQL, and unknown columns (the upstream `UpdateBuilder` wraps
-/// parser errors as invalid-input); `LANCE_ERR_COMMIT_CONFLICT` for a
+/// malformed SQL, and unknown columns; `LANCE_ERR_COMMIT_CONFLICT` for a
 /// concurrent writer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_dataset_update(
@@ -91,8 +90,9 @@ unsafe fn update_inner(
         });
     }
 
-    // Optional predicate. NULL means "update every row"; an explicit empty
-    // string is rejected so callers can't slip a no-op past validation.
+    // Optional predicate. NULL means "update every row"; explicit empty
+    // string is rejected so callers who mean "all rows" go through NULL
+    // rather than a parse error.
     // SAFETY: when non-NULL the caller guarantees `predicate` points to a
     // NUL-terminated C string valid for this call. `parse_c_string` reads
     // by shared reference.
@@ -137,11 +137,9 @@ unsafe fn update_inner(
     let ds = unsafe { &*dataset };
     let rows_updated = ds.with_mut(|d| {
         block_on(async {
-            // Upstream `UpdateBuilder::new` takes `Arc<Dataset>` (it works
-            // off a snapshot rather than `&mut Dataset`). Mirror what
-            // `Dataset::delete` does internally: clone the snapshot for the
-            // builder, then publish `result.new_dataset` into our handle so
-            // subsequent calls observe the new version.
+            // UpdateBuilder takes `Arc<Dataset>` (snapshot-based), so mirror
+            // what `Dataset::delete` does internally: clone for the builder,
+            // then publish `result.new_dataset` back into `*d`.
             let snapshot = Arc::new(d.clone());
             let mut builder = UpdateBuilder::new(snapshot);
             if let Some(p) = predicate_str {

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -6,7 +6,7 @@
 //! These tests call the `extern "C"` functions directly from Rust,
 //! validating the C API contract without needing a C compiler.
 
-use std::ffi::CString;
+use std::ffi::{CString, c_char};
 use std::ptr;
 use std::sync::Arc;
 
@@ -4126,6 +4126,529 @@ fn test_delete_unknown_column_rejected() {
     // Same upstream classification as malformed SQL — see note above.
     assert_eq!(lance_last_error_code(), LanceErrorCode::Internal);
     assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+// ===========================================================================
+// lance_dataset_update
+// ===========================================================================
+
+/// Build a `[*const c_char; N]` ptr array from a slice of `&CString`.
+fn cstr_ptrs(items: &[CString]) -> Vec<*const c_char> {
+    items.iter().map(|s| s.as_ptr()).collect()
+}
+
+#[test]
+fn test_update_basic_predicate() {
+    let (_tmp, uri) = create_large_dataset(100);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let pred = c_str("id < 50");
+    let cols = [c_str("value")];
+    let vals = [c_str("99.0")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+
+    let mut num_updated: u64 = 0;
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            pred.as_ptr(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            &mut num_updated,
+        )
+    };
+    assert_eq!(rc, 0);
+    assert_eq!(num_updated, 50);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 100);
+
+    // Verify the matched rows now read back as 99.0 and the rest are unchanged.
+    let batches = scan_all_rows(ds);
+    let mut updated_count = 0;
+    let mut unchanged_count = 0;
+    for batch in &batches {
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let values = batch
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            let id = ids.value(i);
+            let v = values.value(i);
+            if id < 50 {
+                assert_eq!(v, 99.0, "id={id} should have been updated to 99.0");
+                updated_count += 1;
+            } else {
+                assert_eq!(v, id as f32 * 0.5, "id={id} should be unchanged");
+                unchanged_count += 1;
+            }
+        }
+    }
+    assert_eq!(updated_count, 50);
+    assert_eq!(unchanged_count, 50);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_null_predicate_updates_all() {
+    let (_tmp, uri) = create_large_dataset(20);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let cols = [c_str("label")];
+    let vals = [c_str("'frozen'")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+
+    // NULL predicate → update every row.
+    let mut num_updated: u64 = 0;
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            ptr::null(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            &mut num_updated,
+        )
+    };
+    assert_eq!(rc, 0);
+    assert_eq!(num_updated, 20);
+
+    let batches = scan_all_rows(ds);
+    for batch in &batches {
+        let labels = batch
+            .column_by_name("label")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            assert_eq!(labels.value(i), "frozen");
+        }
+    }
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_multiple_columns() {
+    let (_tmp, uri) = create_large_dataset(10);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let pred = c_str("id = 7");
+    let cols = [c_str("value"), c_str("label")];
+    let vals = [c_str("value * 2"), c_str("'updated'")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+
+    let mut num_updated: u64 = 0;
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            pred.as_ptr(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            2,
+            &mut num_updated,
+        )
+    };
+    assert_eq!(rc, 0);
+    assert_eq!(num_updated, 1);
+
+    // Row 7 originally had value = 3.5, label = "row_7".
+    // After update: value = 7.0, label = "updated". Other rows unchanged.
+    let batches = scan_all_rows(ds);
+    for batch in &batches {
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let values = batch
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap();
+        let labels = batch
+            .column_by_name("label")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            let id = ids.value(i);
+            if id == 7 {
+                assert_eq!(values.value(i), 7.0);
+                assert_eq!(labels.value(i), "updated");
+            } else {
+                assert_eq!(values.value(i), id as f32 * 0.5);
+                assert_eq!(labels.value(i), format!("row_{id}"));
+            }
+        }
+    }
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_no_match_returns_zero() {
+    let (_tmp, uri) = create_large_dataset(10);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let pred = c_str("id > 9999");
+    let cols = [c_str("value")];
+    let vals = [c_str("0.0")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+
+    let mut num_updated: u64 = 12345;
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            pred.as_ptr(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            &mut num_updated,
+        )
+    };
+    assert_eq!(rc, 0);
+    assert_eq!(num_updated, 0);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 10);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_out_param_optional() {
+    let (_tmp, uri) = create_large_dataset(5);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let pred = c_str("id < 3");
+    let cols = [c_str("value")];
+    let vals = [c_str("42.0")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+
+    // Pass NULL out_num_updated — must succeed without writing anything.
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            pred.as_ptr(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, 0);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_bumps_version() {
+    let (_tmp, uri) = create_large_dataset(5);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let v_before = unsafe { lance_dataset_version(ds) };
+    let pred = c_str("id = 0");
+    let cols = [c_str("value")];
+    let vals = [c_str("123.0")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            pred.as_ptr(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, 0);
+    let v_after = unsafe { lance_dataset_version(ds) };
+    assert!(
+        v_after > v_before,
+        "version should increase: before={v_before}, after={v_after}"
+    );
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_null_dataset_rejected() {
+    let cols = [c_str("value")];
+    let vals = [c_str("0.0")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+    let rc = unsafe {
+        lance_dataset_update(
+            ptr::null_mut(),
+            ptr::null(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+}
+
+#[test]
+fn test_update_zero_num_updates_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            ptr::null(),
+            ptr::null(),
+            ptr::null(),
+            0,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_null_columns_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let vals = [c_str("0.0")];
+    let val_ptrs = cstr_ptrs(&vals);
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            ptr::null(),
+            ptr::null(),
+            val_ptrs.as_ptr(),
+            1,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_empty_predicate_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let pred = c_str("");
+    let cols = [c_str("value")];
+    let vals = [c_str("0.0")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            pred.as_ptr(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_empty_column_entry_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let cols = [c_str("")];
+    let vals = [c_str("0.0")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            ptr::null(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_null_entry_in_columns_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    // Build an array where the first column pointer is NULL.
+    let val_a = c_str("0.0");
+    let col_ptrs: [*const c_char; 1] = [ptr::null()];
+    let val_ptrs: [*const c_char; 1] = [val_a.as_ptr()];
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            ptr::null(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_invalid_predicate_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    // Garbage SQL — UpdateBuilder::update_where wraps parser errors as
+    // InvalidInput, so this surfaces as InvalidArgument (different from
+    // lance_dataset_delete, which routes through a different upstream path
+    // and surfaces these as Internal).
+    let pred = c_str("not a real predicate ((((");
+    let cols = [c_str("value")];
+    let vals = [c_str("0.0")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            pred.as_ptr(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_update_unknown_column_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let cols = [c_str("no_such_column")];
+    let vals = [c_str("0.0")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            ptr::null(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, -1);
+    // UpdateBuilder::set returns InvalidInput for unknown columns.
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+// Locks in the documented contract: when the call fails, `out_num_updated`
+// must be left unchanged. A future refactor that pre-zeroes the slot before
+// validating inputs would silently break this guarantee.
+#[test]
+fn test_update_out_param_untouched_on_error() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let mut sentinel: u64 = 0xDEAD_BEEF;
+
+    // Empty predicate → INVALID_ARGUMENT before any work happens (boundary).
+    let pred = c_str("");
+    let cols = [c_str("value")];
+    let vals = [c_str("0.0")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            pred.as_ptr(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            &mut sentinel,
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(sentinel, 0xDEAD_BEEF, "out slot must be untouched on error");
+
+    // Same property must hold for upstream-surfaced errors (unknown column).
+    let bad_cols = [c_str("no_such_column")];
+    let bad_col_ptrs = cstr_ptrs(&bad_cols);
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            ptr::null(),
+            bad_col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            &mut sentinel,
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(sentinel, 0xDEAD_BEEF, "out slot must be untouched on error");
 
     unsafe { lance_dataset_close(ds) };
 }

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -4465,6 +4465,30 @@ fn test_update_null_columns_rejected() {
 }
 
 #[test]
+fn test_update_null_values_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let cols = [c_str("value")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            ptr::null(),
+            col_ptrs.as_ptr(),
+            ptr::null(),
+            1,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
 fn test_update_empty_predicate_rejected() {
     let (_tmp, uri) = create_large_dataset(3);
     let c_uri = c_str(&uri);
@@ -4598,6 +4622,36 @@ fn test_update_unknown_column_rejected() {
     };
     assert_eq!(rc, -1);
     // UpdateBuilder::set returns InvalidInput for unknown columns.
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+// Predicate-side unknown column goes through `UpdateBuilder::update_where`
+// (a different upstream path from `set`), so pin it separately.
+#[test]
+fn test_update_unknown_predicate_column_rejected() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let pred = c_str("no_such_column = 1");
+    let cols = [c_str("value")];
+    let vals = [c_str("0.0")];
+    let col_ptrs = cstr_ptrs(&cols);
+    let val_ptrs = cstr_ptrs(&vals);
+    let rc = unsafe {
+        lance_dataset_update(
+            ds,
+            pred.as_ptr(),
+            col_ptrs.as_ptr(),
+            val_ptrs.as_ptr(),
+            1,
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, -1);
     assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
     assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
 

--- a/tests/cpp/test_c_api.c
+++ b/tests/cpp/test_c_api.c
@@ -269,6 +269,38 @@ static void test_dataset_write_roundtrip(const char *src_uri, const char *dst_ur
 }
 
 /* Re-opens the dataset just written by `test_dataset_write_roundtrip` and
+ * exercises `lance_dataset_update`. Must run before `test_delete`, which
+ * empties the dataset. */
+static void test_update(const char *write_uri) {
+    printf("  test_update... ");
+
+    LanceDataset *ds = lance_dataset_open(write_uri, NULL, 0);
+    ASSERT(ds != NULL, "open failed");
+
+    uint64_t before = lance_dataset_count_rows(ds);
+    CHECK_OK();
+    ASSERT(before > 0, "fixture expected to have rows");
+
+    /* Set every row's `name` column to a literal (NULL predicate -> all rows). */
+    const char *cols[] = {"name"};
+    const char *vals[] = {"'frozen'"};
+    uint64_t updated = 0;
+    int32_t rc = lance_dataset_update(ds, NULL, cols, vals, 1, &updated);
+    ASSERT(rc == 0, "update failed");
+    ASSERT(updated == before, "updated count mismatch");
+    ASSERT(lance_dataset_count_rows(ds) == before, "row count must be unchanged");
+
+    /* num_updates == 0 must be rejected. */
+    rc = lance_dataset_update(ds, NULL, NULL, NULL, 0, NULL);
+    ASSERT(rc == -1, "num_updates=0 must fail");
+    ASSERT(lance_last_error_code() == LANCE_ERR_INVALID_ARGUMENT,
+           "expected INVALID_ARGUMENT");
+
+    lance_dataset_close(ds);
+    printf("updated=%llu... OK\n", (unsigned long long)updated);
+}
+
+/* Re-opens the dataset just written by `test_dataset_write_roundtrip` and
  * exercises `lance_dataset_delete`. Must run after the write roundtrip. */
 static void test_delete(const char *write_uri) {
     printf("  test_delete... ");
@@ -314,6 +346,7 @@ int main(int argc, char **argv) {
     test_restore_to_current(uri);
     test_error_handling();
     test_dataset_write_roundtrip(uri, write_uri);
+    test_update(write_uri);
     test_delete(write_uri);
 
     printf("All C tests passed!\n");

--- a/tests/cpp/test_cpp_api.cpp
+++ b/tests/cpp/test_cpp_api.cpp
@@ -303,6 +303,35 @@ static void test_dataset_write_roundtrip(const std::string& src_uri,
 }
 
 // Re-opens the dataset just written by `test_dataset_write_roundtrip` and
+// exercises `Dataset::update`. Must run before `test_delete_rows`, which
+// empties the dataset.
+static void test_update(const std::string& dst_uri) {
+    TEST(test_update);
+
+    auto ds = lance::Dataset::open(dst_uri);
+    uint64_t before = ds.count_rows();
+    assert(before > 0 && "test fixture expected to have rows");
+
+    // Empty predicate -> updates every row.
+    uint64_t updated = ds.update("", {{"name", "'frozen'"}});
+    assert(updated == before);
+    assert(ds.count_rows() == before);
+
+    // Empty updates vector must throw (num_updates == 0).
+    bool caught_empty = false;
+    try {
+        ds.update("", {});
+    } catch (const lance::Error& e) {
+        caught_empty = true;
+        assert(e.code == LANCE_ERR_INVALID_ARGUMENT);
+    }
+    assert(caught_empty);
+
+    printf("updated=%llu... ", (unsigned long long)updated);
+    PASS();
+}
+
+// Re-opens the dataset just written by `test_dataset_write_roundtrip` and
 // exercises `Dataset::delete_rows`. Must run after the write roundtrip.
 static void test_delete_rows(const std::string& dst_uri) {
     TEST(test_delete_rows);
@@ -352,6 +381,7 @@ int main(int argc, char** argv) {
     test_nearest_smoke(uri);
     test_fts_smoke(uri);
     test_dataset_write_roundtrip(uri, write_uri);
+    test_update(write_uri);
     test_delete_rows(write_uri);
 
     printf("All C++ tests passed!\n");


### PR DESCRIPTION
## Summary

Adds `lance_dataset_update` — the next predicate-driven mutation primitive after `_delete`. Callers pass an optional SQL filter (NULL = all rows) plus parallel arrays of column names and SQL value expressions. Same `with_mut` + `block_on` shape as delete, same lock semantics for in-flight scanners.

C++ wrapper: `Dataset::update(predicate, vector<pair<string,string>>) -> uint64_t`. Empty `predicate` routes to NULL on the C side. Updated row count comes back via the optional out param (NULL discards it).

Closes #32.

## Error semantics

| Code | When |
|---|---|
| `LANCE_ERR_INVALID_ARGUMENT` | NULL dataset, `num_updates == 0`, NULL/empty entries in `columns`/`values`, or an explicit empty `predicate`. Also malformed SQL filters/expressions and unknown column names — both `update_where` and `set` upstream wrap parser errors as `Error::InvalidInput`, so they surface as `INVALID_ARGUMENT` (not `INTERNAL` like delete). Tests pin both the predicate-side and set-side classifications. |
| `LANCE_ERR_COMMIT_CONFLICT` | Concurrent writer landed a manifest first. |

## Design notes

- `out_num_updated` is left untouched on error — every error path returns before the write. `test_update_out_param_untouched_on_error` locks this in with a `0xDEAD_BEEF` sentinel against a boundary path (empty predicate) and an upstream-surfaced path (unknown column).
- `predicate == NULL` updates every row; explicit empty string is rejected so callers go through NULL rather than a parse error.
- The validation loop materializes owned `(column, value)` pairs up front, before taking the write lock — bad input gets a precise `columns[i]`/`values[i]` error message instead of tying up the writer.
- Mirrors `lance_dataset_delete`: `unsafe fn`, `ffi_try!`, `with_mut(|d| block_on(...))`, SAFETY comments. `Arc::try_unwrap(...).unwrap_or_else(|arc| (*arc).clone())` matches what upstream `Dataset::delete` does internally for publishing the new dataset back into `*d`.

## Test plan

- `cargo test` — **132 passed**, 0 failed. 17 new update tests:
  - `test_update_basic_predicate` — `WHERE id < 50 SET value = 99.0` on 100 rows → 50 updated; reads back the matched and unmatched rows to confirm only the matched ones changed.
  - `test_update_null_predicate_updates_all` — `predicate == NULL`, `SET label = 'frozen'` on 20 rows; every row reads back as `'frozen'`.
  - `test_update_multiple_columns` — `id = 7 SET value = value * 2, label = 'updated'`; per-row expression evaluation.
  - `test_update_no_match_returns_zero` — predicate matches nothing → count = 0, dataset unchanged.
  - `test_update_out_param_optional` — NULL `out_num_updated` succeeds.
  - `test_update_out_param_untouched_on_error` — sentinel preserved on every error path.
  - `test_update_bumps_version` — version strictly increases on success.
  - Boundary validation, `LANCE_ERR_INVALID_ARGUMENT`: `test_update_null_dataset_rejected`, `test_update_zero_num_updates_rejected`, `test_update_null_columns_rejected`, `test_update_null_values_rejected`, `test_update_empty_predicate_rejected`, `test_update_empty_column_entry_rejected`, `test_update_null_entry_in_columns_rejected`.
  - Upstream-surfaced, `LANCE_ERR_INVALID_ARGUMENT`: `test_update_invalid_predicate_rejected`, `test_update_unknown_column_rejected` (set-side via `UpdateBuilder::set`), `test_update_unknown_predicate_column_rejected` (predicate-side via `UpdateBuilder::update_where` — pinned separately because it's a different upstream path).
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean.
- `cargo test --test compile_and_run_test -- --ignored` — C and C++ integration tests pass; both exercise the new wrapper end-to-end (`SET name = 'frozen'` against the write-roundtrip dataset, plus a `num_updates == 0` rejection).

## Out of scope

`lance_dataset_merge_insert` (upsert) is the natural follow-on — richer builder surface (`when_matched` / `when_not_matched_insert` / etc.), so it deserves its own design pass, but it'll reuse the same `with_mut` + `block_on` plumbing.