### PR TITLE
fix(cmake): strip pre-release suffix before project(VERSION ...)

### DIFF
--- a/cmake/cargo-version.cmake
+++ b/cmake/cargo-version.cmake
@@ -2,11 +2,15 @@
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
 # Read the version field from Cargo.toml's [package] section.
-# Sets ${out_var} in the parent scope.
+#
+# Sets ${out_var} to the numeric X.Y.Z portion (CMake's project(VERSION ...)
+# rejects pre-release suffixes like "-beta.1"). Also sets ${out_var}_FULL to
+# the complete version string including any suffix (for display/metadata).
 function(read_cargo_version cargo_toml out_var)
     file(READ "${cargo_toml}" _cargo_contents)
-    if(NOT _cargo_contents MATCHES "\\[package\\][^[]*\nversion[ \t]*=[ \t]*\"([0-9]+\\.[0-9]+\\.[0-9]+[^\"]*)\"")
+    if(NOT _cargo_contents MATCHES "\\[package\\][^[]*\nversion[ \t]*=[ \t]*\"([0-9]+\\.[0-9]+\\.[0-9]+)([^\"]*)\"")
         message(FATAL_ERROR "Could not parse version from ${cargo_toml}")
     endif()
     set(${out_var} "${CMAKE_MATCH_1}" PARENT_SCOPE)
+    set(${out_var}_FULL "${CMAKE_MATCH_1}${CMAKE_MATCH_2}" PARENT_SCOPE)
 endfunction()

--- a/cmake/test_cargo_version.cmake
+++ b/cmake/test_cargo_version.cmake
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+#
+# Self-contained tests for read_cargo_version. Run with:
+#   cmake -P cmake/test_cargo_version.cmake
+
+cmake_minimum_required(VERSION 3.22)
+
+include("${CMAKE_CURRENT_LIST_DIR}/cargo-version.cmake")
+
+set(_tmp_dir "${CMAKE_CURRENT_LIST_DIR}/.test_cargo_version_tmp")
+file(MAKE_DIRECTORY "${_tmp_dir}")
+
+function(_check label cargo_body expected_clean expected_full)
+    set(_toml "${_tmp_dir}/${label}.toml")
+    file(WRITE "${_toml}" "${cargo_body}")
+
+    read_cargo_version("${_toml}" v)
+
+    if(NOT v STREQUAL "${expected_clean}")
+        message(FATAL_ERROR "[${label}] expected v='${expected_clean}', got '${v}'")
+    endif()
+    if(NOT v_FULL STREQUAL "${expected_full}")
+        message(FATAL_ERROR "[${label}] expected v_FULL='${expected_full}', got '${v_FULL}'")
+    endif()
+    message(STATUS "[${label}] OK: v=${v}, v_FULL=${v_FULL}")
+endfunction()
+
+_check(stable
+    "[package]\nname = \"lance-c\"\nversion = \"0.1.0\"\n"
+    "0.1.0" "0.1.0")
+
+_check(beta
+    "[package]\nname = \"lance-c\"\nversion = \"0.2.0-beta.1\"\n"
+    "0.2.0" "0.2.0-beta.1")
+
+_check(beta_double_digit
+    "[package]\nname = \"lance-c\"\nversion = \"0.1.1-beta.10\"\n"
+    "0.1.1" "0.1.1-beta.10")
+
+_check(rc
+    "[package]\nname = \"lance-c\"\nversion = \"1.0.0-rc.3\"\n"
+    "1.0.0" "1.0.0-rc.3")
+
+_check(major_release
+    "[package]\nname = \"lance-c\"\nversion = \"2.0.0\"\n"
+    "2.0.0" "2.0.0")
+
+# Cleanup
+file(REMOVE_RECURSE "${_tmp_dir}")
+message(STATUS "All read_cargo_version tests passed.")

--- a/tests/cmake_helpers_test.rs
+++ b/tests/cmake_helpers_test.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Tests for the CMake helpers under `cmake/` that aren't directly exercised by
+//! Rust code but are critical to the `find_package(LanceC)` consumer story.
+//!
+//! These tests `cmake -P` standalone CMake scripts that assert on `read_cargo_version`
+//! and friends. CMake is pre-installed on every GitHub-hosted runner, so this
+//! runs in the standard CI lane (no `--ignored` gate).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn read_cargo_version_handles_stable_and_prerelease_inputs() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let script = manifest_dir.join("cmake").join("test_cargo_version.cmake");
+
+    let output = Command::new("cmake")
+        .arg("-P")
+        .arg(&script)
+        .output()
+        .unwrap_or_else(|e| panic!("cmake not available on PATH: {e}"));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "cmake -P {} failed (exit {:?})\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        script.display(),
+        output.status.code(),
+    );
+    let combined = format!("{stdout}\n{stderr}");
+    assert!(
+        combined.contains("All read_cargo_version tests passed."),
+        "expected success marker, got:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Unblocks the broken v0.1.1-beta.1 release ([failed run](https://github.com/lance-format/lance-c/actions/runs/25244983310)). CMake's `project(VERSION ...)` only accepts `X.Y.Z[.W]` and rejects pre-release suffixes like `-beta.1`:

```
CMake Error at CMakeLists.txt:10 (project):
  VERSION "0.1.1-beta.1" format invalid.
```

Update `read_cargo_version` to capture the numeric `X.Y.Z` portion (for `project()`) and expose the complete string (with any `-beta.N` / `-rc.N` suffix) as `${out_var}_FULL` for callers that want it. CMakeLists.txt needs no change — `LANCE_C_VERSION` keeps the same name, just gets the clean version now.

## Tests

New `cmake/test_cargo_version.cmake` covers stable / beta / beta with double-digit / rc / major cases, run via `cmake -P`. Wired into `cargo test` via `tests/cmake_helpers_test.rs` (cmake is pre-installed on every GH-hosted runner, so no new CI deps).

```
$ cargo test --test cmake_helpers_test
test read_cargo_version_handles_stable_and_prerelease_inputs ... ok
```

## After this lands

The existing tag `v0.1.1-beta.1` points at commit `2347c33` (which doesn't have this fix). Two paths:

1. **Re-run release on a fresh tag** — once this PR merges, run **Create Release** with `release_type=current`, `release_channel=preview`. The workflow will see existing `v0.1.1-beta.1` tag and cut `v0.1.1-beta.2` from a commit that includes this fix. The old tag stays as a record of the failed attempt (delete it with `git push --delete origin v0.1.1-beta.1` if you want a clean slate).
2. **Force-update the existing tag** — `git tag -f v0.1.1-beta.1 <merge-commit>` and force-push, then re-run release.yml. Less history churn but rewrites a published tag.

Recommend path 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)