### PR TITLE
chore(ci): drop x86_64-apple-darwin from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
             os_label: linux
-          - target: x86_64-apple-darwin
-            runner: macos-13
-            os_label: macos
+          # x86_64-apple-darwin temporarily disabled: GitHub is deprecating
+          # macos-13 runners and jobs queue 24h+ before timing out. Restore
+          # this row once a macos-* Intel runner is reliably available again.
           - target: aarch64-apple-darwin
             runner: macos-14
             os_label: macos

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ auto ds = lance::Dataset::open("data.lance", {}, /*version=*/42);
 
 ## Releasing
 
-Releases are tag-driven: pushing a `v*.*.*` tag fires [`release.yml`](.github/workflows/release.yml), which builds prebuilt tarballs for `linux-{x86_64,aarch64}` and `macos-{x86_64,aarch64}` and attaches them to a GitHub Release. Beta tags (`v*-beta.*`) are published as pre-releases.
+Releases are tag-driven: pushing a `v*.*.*` tag fires [`release.yml`](.github/workflows/release.yml), which builds prebuilt tarballs for `linux-{x86_64,aarch64}` and `macos-aarch64` and attaches them to a GitHub Release. Beta tags (`v*-beta.*`) are published as pre-releases. (`macos-x86_64` is temporarily disabled — see the matrix comment in `release.yml`.)
 
 ### Recommended: cut a release via Actions UI
 


### PR DESCRIPTION
## Summary

The v0.1.2 release attempt ([run](https://github.com/lance-format/lance-c/actions/runs/25245366712)) had its [`x86_64-apple-darwin` job](https://github.com/lance-format/lance-c/actions/runs/25245366712/job/74028627388) queue 24h before timing out — GitHub is deprecating `macos-13` runners (matches the actionlint warning we saw earlier flagging `macos-13` as an unknown label). That blocked the publish job (`needs: build`).

Drop the row from the release matrix temporarily. Comment in the matrix points at restoring this once a `macos-*` Intel runner is reliably available again.

The other 3 platforms (`x86_64-linux`, `aarch64-linux`, `aarch64-darwin`) all built successfully on that run.

## Out of scope

The conan/vcpkg recipes (`recipes/lance-c/all/conandata.yml`, `ports/lance-c/portfile.cmake`, `recipes/lance-c/all/conanfile.py`) still reference `x86_64-apple-darwin` with placeholder `v0.1.0` URLs. Those are pre-1.0 aspirational and were never wired to real tarballs — leaving them as a separate cleanup once we decide whether Intel macOS comes back or is dropped permanently.

## After this lands

The `v0.1.2` tag still points at `c801dfe` (which has the broken matrix). Two options:

1. **Re-cut as v0.1.3** — easiest. After this PR merges, run **Create Release** with `release_type=patch, release_channel=stable` to cut a fresh `v0.1.3` from a commit with the fixed matrix.
2. **Reuse v0.1.2** — `git push --delete origin v0.1.2`, then run **Create Release** with `release_type=current, release_channel=stable` to re-cut `v0.1.2` from main.

Recommend (1) — keeps tag history honest, the `v0.1.2` tag stays as a marker of a real attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)