### PR TITLE
feat: add lance_dataset_compact_files for fragment compaction

### DIFF
--- a/include/lance/lance.h
+++ b/include/lance/lance.h
@@ -390,6 +390,69 @@ int32_t lance_dataset_merge_insert(
     LanceMergeInsertResult* out_result
 );
 
+/* ─── lance_dataset_compact_files ─────────────────────────────────────────── */
+
+/**
+ * Tunable parameters for lance_dataset_compact_files. Pass NULL to use the
+ * upstream defaults. Each numeric field uses 0 as a "keep upstream default"
+ * sentinel; non-zero values are forwarded after a usize range check so the
+ * API does not silently truncate on 32-bit hosts.
+ */
+typedef struct LanceCompactionOptions {
+    /* Target row count per output fragment. Fragments below this size are
+       candidates for being merged with neighbors. 0 = default (~1Mi rows). */
+    uint64_t target_rows_per_fragment;
+    /* Soft cap on rows per row group within an output fragment. 0 = default. */
+    uint64_t max_rows_per_group;
+    /* Soft cap on bytes per output fragment file. 0 = default (writer cap). */
+    uint64_t max_bytes_per_file;
+    /* Compute parallelism for compaction tasks. 0 = default
+       (number of compute-intensive CPUs). */
+    uint32_t num_threads;
+    /* Scanner batch size for reading input fragments. 0 = default. */
+    uint64_t batch_size;
+} LanceCompactionOptions;
+
+/** Per-call compaction metrics returned via the optional out parameter. */
+typedef struct LanceCompactionMetrics {
+    /* Number of input fragments that were rewritten and dropped. */
+    uint64_t fragments_removed;
+    /* Number of new fragments produced by the rewrite. */
+    uint64_t fragments_added;
+    /* Total files removed across the operation, including deletion files. */
+    uint64_t files_removed;
+    /* Total files added across the operation; one per new fragment. */
+    uint64_t files_added;
+} LanceCompactionMetrics;
+
+/**
+ * Compact the dataset's fragments, committing a new manifest if anything
+ * changed. Each compaction task merges adjacent small fragments and
+ * materializes any deletion files in the process. A clean dataset (no
+ * fragment under the target size, no deletions worth materializing) is a
+ * no-op: the function returns success with all-zero metrics and the
+ * dataset's version is unchanged.
+ *
+ * Mutates `dataset` in place — the same handle remains valid afterward and
+ * sees the new version. Scanners already in flight against this dataset
+ * keep their pre-compaction snapshot view.
+ *
+ * @param dataset      Open dataset (not consumed). Must not be NULL.
+ * @param options      Tunable parameters. Pass NULL for upstream defaults.
+ * @param out_metrics  Optional. If non-NULL, on success receives the per-call
+ *                     compaction metrics. On error the slot is left unchanged
+ *                     — do not read it.
+ * @return 0 on success, -1 on error. Error codes:
+ *         LANCE_ERR_INVALID_ARGUMENT for NULL `dataset` or for numeric
+ *         overrides that exceed usize::MAX on the running target;
+ *         LANCE_ERR_COMMIT_CONFLICT for a concurrent writer.
+ */
+int32_t lance_dataset_compact_files(
+    LanceDataset* dataset,
+    const LanceCompactionOptions* options,
+    LanceCompactionMetrics* out_metrics
+);
+
 /**
  * Export the dataset schema via Arrow C Data Interface.
  * @param out  Pointer to caller-allocated ArrowSchema struct

--- a/include/lance/lance.h
+++ b/include/lance/lance.h
@@ -408,7 +408,7 @@ typedef struct LanceCompactionOptions {
     uint64_t max_bytes_per_file;
     /* Compute parallelism for compaction tasks. 0 = default
        (number of compute-intensive CPUs). */
-    uint32_t num_threads;
+    uint64_t num_threads;
     /* Scanner batch size for reading input fragments. 0 = default. */
     uint64_t batch_size;
 } LanceCompactionOptions;

--- a/include/lance/lance.hpp
+++ b/include/lance/lance.hpp
@@ -423,6 +423,19 @@ public:
         return merge_insert(on_columns, source, &params);
     }
 
+    /// Compact small or deleted-heavy fragments into larger ones, committing
+    /// a new manifest. A clean dataset is a no-op — all-zero metrics and the
+    /// version is unchanged. Pass `nullptr` for upstream defaults.
+    /// Throws lance::Error on failure (commit conflict, ...).
+    LanceCompactionMetrics compact_files(
+        const LanceCompactionOptions* options = nullptr) {
+        LanceCompactionMetrics metrics{};
+        if (lance_dataset_compact_files(handle_.get(), options, &metrics) != 0) {
+            check_error();
+        }
+        return metrics;
+    }
+
     /// Export the schema as an Arrow C Data Interface struct.
     void schema(ArrowSchema* out) const {
         if (lance_dataset_schema(handle_.get(), out) != 0) {

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Compaction C API: rewrite small/deleted-heavy fragments into larger ones,
+//! committing a new manifest. Operates as a no-op (no version bump) when no
+//! fragments need compacting.
+//!
+//! Mutates the dataset in place under an exclusive write lock; existing
+//! scanners that already cloned the inner Arc keep their pre-compaction
+//! snapshot view.
+
+use lance::dataset::optimize::{CompactionOptions, compact_files};
+use lance_core::Result;
+
+use crate::dataset::LanceDataset;
+use crate::error::ffi_try;
+use crate::runtime::block_on;
+
+/// Tunable parameters for `lance_dataset_compact_files`. Pass NULL to use the
+/// upstream defaults. Each numeric field uses `0` as a "keep upstream default"
+/// sentinel; explicit overrides are forwarded after a `usize` range check.
+///
+/// The struct is `#[repr(C)]` and ABI-stable within a minor version; new
+/// fields can be appended without breaking existing callers.
+#[repr(C)]
+pub struct LanceCompactionOptions {
+    /// Target row count per output fragment. Fragments below this size are
+    /// candidates for being merged with neighbors. `0` uses upstream's
+    /// default (~1Mi rows).
+    pub target_rows_per_fragment: u64,
+    /// Soft cap on rows per row group within an output fragment. `0` uses
+    /// upstream's default.
+    pub max_rows_per_group: u64,
+    /// Soft cap on bytes per output fragment file. `0` uses upstream's
+    /// default (the writer's per-file cap).
+    pub max_bytes_per_file: u64,
+    /// Compute parallelism for compaction tasks. `0` uses upstream's default
+    /// (the number of compute-intensive CPUs).
+    pub num_threads: u32,
+    /// Scanner batch size for reading input fragments. `0` uses upstream's
+    /// default.
+    pub batch_size: u64,
+}
+
+/// Per-call compaction metrics returned via the optional out parameter.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct LanceCompactionMetrics {
+    /// Number of input fragments that were rewritten and dropped.
+    pub fragments_removed: u64,
+    /// Number of new fragments produced by the rewrite.
+    pub fragments_added: u64,
+    /// Total files removed across the operation, including deletion files.
+    pub files_removed: u64,
+    /// Total files added across the operation; one per new fragment.
+    pub files_added: u64,
+}
+
+/// Compact the dataset's fragments, committing a new manifest if anything
+/// changed.
+///
+/// Each compaction task merges adjacent small fragments and materializes any
+/// deletion files in the process. A clean dataset (no fragment under the
+/// target size, no deletions worth materializing) is a no-op: the function
+/// returns success with all-zero metrics and the dataset's version is
+/// unchanged.
+///
+/// - `dataset`: Open dataset (mutated; same handle remains valid afterward).
+///   Must not be NULL.
+/// - `options`: Optional. NULL uses upstream defaults; otherwise each field
+///   is treated as an override (`0` keeps the default for that field).
+/// - `out_metrics`: Optional. If non-NULL, on success receives the
+///   `LanceCompactionMetrics` for this call. On error the slot is untouched.
+///
+/// Returns 0 on success, -1 on error. Error codes:
+/// `LANCE_ERR_INVALID_ARGUMENT` for NULL `dataset` or for numeric overrides
+/// that exceed `usize::MAX` on the running target;
+/// `LANCE_ERR_COMMIT_CONFLICT` for a concurrent writer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn lance_dataset_compact_files(
+    dataset: *mut LanceDataset,
+    options: *const LanceCompactionOptions,
+    out_metrics: *mut LanceCompactionMetrics,
+) -> i32 {
+    ffi_try!(unsafe { compact_inner(dataset, options, out_metrics) }, neg)
+}
+
+unsafe fn compact_inner(
+    dataset: *mut LanceDataset,
+    options: *const LanceCompactionOptions,
+    out_metrics: *mut LanceCompactionMetrics,
+) -> Result<i32> {
+    if dataset.is_null() {
+        return Err(lance_core::Error::InvalidInput {
+            source: "dataset must not be NULL".into(),
+            location: snafu::location!(),
+        });
+    }
+
+    // SAFETY: `options` is either NULL (use defaults) or points to a valid
+    // `LanceCompactionOptions` for the duration of this call. `resolve` only
+    // reads through the pointer.
+    let resolved = unsafe { resolve_options(options)? };
+
+    // SAFETY: `dataset` is non-NULL (checked above) and the caller guarantees
+    // it points to a live `LanceDataset` not aliased mutably elsewhere.
+    let ds = unsafe { &*dataset };
+    let metrics = ds.with_mut(|d| block_on(compact_files(d, resolved, None)))?;
+
+    if !out_metrics.is_null() {
+        // SAFETY: caller guarantees `out_metrics` (when non-NULL) points to
+        // caller-owned, writable storage of size `sizeof(LanceCompactionMetrics)`.
+        // We only write on success; on the error paths above the slot stays
+        // untouched per the documented contract.
+        unsafe {
+            *out_metrics = LanceCompactionMetrics {
+                fragments_removed: metrics.fragments_removed as u64,
+                fragments_added: metrics.fragments_added as u64,
+                files_removed: metrics.files_removed as u64,
+                files_added: metrics.files_added as u64,
+            };
+        }
+    }
+    Ok(0)
+}
+
+/// Build a `CompactionOptions` from the caller-provided overrides (or NULL
+/// → all defaults). Each numeric field uses `0` as a "keep upstream default"
+/// sentinel; non-zero values are forwarded after a `usize` range check so
+/// the API doesn't silently truncate on 32-bit hosts.
+unsafe fn resolve_options(options: *const LanceCompactionOptions) -> Result<CompactionOptions> {
+    let mut resolved = CompactionOptions::default();
+    if options.is_null() {
+        return Ok(resolved);
+    }
+
+    // SAFETY: `options` is non-NULL (checked above) and the caller guarantees
+    // it points to a properly-initialized `LanceCompactionOptions` valid for
+    // the duration of this call. We read by shared reference.
+    let opts = unsafe { &*options };
+
+    if opts.target_rows_per_fragment > 0 {
+        resolved.target_rows_per_fragment =
+            u64_to_usize(opts.target_rows_per_fragment, "target_rows_per_fragment")?;
+    }
+    if opts.max_rows_per_group > 0 {
+        resolved.max_rows_per_group = u64_to_usize(opts.max_rows_per_group, "max_rows_per_group")?;
+    }
+    if opts.max_bytes_per_file > 0 {
+        resolved.max_bytes_per_file =
+            Some(u64_to_usize(opts.max_bytes_per_file, "max_bytes_per_file")?);
+    }
+    if opts.num_threads > 0 {
+        resolved.num_threads = Some(opts.num_threads as usize);
+    }
+    if opts.batch_size > 0 {
+        resolved.batch_size = Some(u64_to_usize(opts.batch_size, "batch_size")?);
+    }
+    Ok(resolved)
+}
+
+/// Narrow `u64 -> usize` with an explicit error on overflow (32-bit hosts).
+/// Realistic compaction tunings fit in `usize` on every supported target,
+/// but a silent `as` cast would wrap on a 32-bit host.
+fn u64_to_usize(v: u64, field: &'static str) -> Result<usize> {
+    usize::try_from(v).map_err(|_| lance_core::Error::InvalidInput {
+        source: format!("{field}={v} exceeds usize::MAX on this target").into(),
+        location: snafu::location!(),
+    })
+}

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -124,10 +124,9 @@ unsafe fn compact_inner(
     Ok(0)
 }
 
-/// Build a `CompactionOptions` from the caller-provided overrides (or NULL
-/// → all defaults). Each numeric field uses `0` as a "keep upstream default"
-/// sentinel; non-zero values are forwarded after a `usize` range check so
-/// the API doesn't silently truncate on 32-bit hosts.
+/// Apply caller-provided overrides onto a default `CompactionOptions`. NULL
+/// means "no overrides"; the per-field sentinel and overflow contract are
+/// documented on `LanceCompactionOptions`.
 unsafe fn resolve_options(options: *const LanceCompactionOptions) -> Result<CompactionOptions> {
     let mut resolved = CompactionOptions::default();
     if options.is_null() {

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -36,7 +36,7 @@ pub struct LanceCompactionOptions {
     pub max_bytes_per_file: u64,
     /// Compute parallelism for compaction tasks. `0` uses upstream's default
     /// (the number of compute-intensive CPUs).
-    pub num_threads: u32,
+    pub num_threads: u64,
     /// Scanner batch size for reading input fragments. `0` uses upstream's
     /// default.
     pub batch_size: u64,
@@ -151,7 +151,7 @@ unsafe fn resolve_options(options: *const LanceCompactionOptions) -> Result<Comp
             Some(u64_to_usize(opts.max_bytes_per_file, "max_bytes_per_file")?);
     }
     if opts.num_threads > 0 {
-        resolved.num_threads = Some(opts.num_threads as usize);
+        resolved.num_threads = Some(u64_to_usize(opts.num_threads, "num_threads")?);
     }
     if opts.batch_size > 0 {
         resolved.batch_size = Some(u64_to_usize(opts.batch_size, "batch_size")?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 
 mod async_dispatcher;
 mod batch;
+mod compact;
 mod dataset;
 mod delete;
 mod error;
@@ -33,6 +34,7 @@ mod writer;
 
 // Re-export all extern "C" symbols so they appear in the cdylib.
 pub use batch::*;
+pub use compact::*;
 pub use dataset::*;
 pub use delete::*;
 pub use error::{

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -5771,3 +5771,297 @@ fn test_merge_insert_unknown_predicate_column_in_delete_if_rejected() {
     assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
     unsafe { lance_dataset_close(ds) };
 }
+
+// ===========================================================================
+// lance_dataset_compact_files
+// ===========================================================================
+
+/// Build a dataset of `num_fragments` small fragments (3 unique ids each)
+/// so the default planner sees plenty of small neighbors to merge. Unique
+/// ids keep fragments alive across partial-row deletes — upstream's `delete`
+/// drops a fragment entirely once all of its rows are gone.
+fn create_many_small_fragments(num_fragments: i32) -> (tempfile::TempDir, String) {
+    let tmp = tempfile::tempdir().unwrap();
+    let uri = tmp.path().join("small_frags").to_str().unwrap().to_string();
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+
+    lance_c::runtime::block_on(async {
+        for i in 0..num_fragments {
+            let base = i * 3;
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(vec![base, base + 1, base + 2]))],
+            )
+            .unwrap();
+            if i == 0 {
+                Dataset::write(
+                    arrow::record_batch::RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+                    &uri,
+                    None,
+                )
+                .await
+                .unwrap();
+            } else {
+                let mut ds = Dataset::open(&uri).await.unwrap();
+                ds.append(
+                    arrow::record_batch::RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+                    None,
+                )
+                .await
+                .unwrap();
+            }
+        }
+    });
+
+    (tmp, uri)
+}
+
+#[test]
+fn test_compact_basic_merges_small_fragments() {
+    let (_tmp, uri) = create_many_small_fragments(4);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    assert_eq!(unsafe { lance_dataset_fragment_count(ds) }, 4);
+    let v_before = unsafe { lance_dataset_version(ds) };
+
+    let mut metrics = LanceCompactionMetrics::default();
+    let rc = unsafe { lance_dataset_compact_files(ds, ptr::null(), &mut metrics) };
+    assert_eq!(rc, 0);
+
+    // All four small neighbors are below the default 1Mi target, so they
+    // collapse into a single output fragment. Row count is preserved.
+    assert_eq!(metrics.fragments_removed, 4);
+    assert_eq!(metrics.fragments_added, 1);
+    assert_eq!(unsafe { lance_dataset_fragment_count(ds) }, 1);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 12);
+    assert!(unsafe { lance_dataset_version(ds) } > v_before);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_compact_preserves_data() {
+    let (_tmp, uri) = create_many_small_fragments(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let rc = unsafe { lance_dataset_compact_files(ds, ptr::null(), ptr::null_mut()) };
+    assert_eq!(rc, 0);
+
+    // Three fragments × three unique ids each = 0..=8, every value once.
+    let mut seen = [false; 9];
+    for batch in &scan_all_rows(ds) {
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            seen[ids.value(i) as usize] = true;
+        }
+    }
+    assert!(seen.iter().all(|&b| b));
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_compact_no_op_on_clean_single_fragment() {
+    // A single fragment with no neighbors and no deletions has nothing to
+    // compact: upstream returns success without committing, so the version
+    // and counts are unchanged.
+    let (_tmp, uri) = create_test_dataset();
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let v_before = unsafe { lance_dataset_version(ds) };
+    let mut metrics = LanceCompactionMetrics {
+        fragments_removed: 0xDEAD,
+        fragments_added: 0xBEEF,
+        files_removed: 0xCAFE,
+        files_added: 0xF00D,
+    };
+    let rc = unsafe { lance_dataset_compact_files(ds, ptr::null(), &mut metrics) };
+    assert_eq!(rc, 0);
+    assert_eq!(metrics, LanceCompactionMetrics::default());
+    assert_eq!(unsafe { lance_dataset_version(ds) }, v_before);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_compact_after_deletes_materializes_deletion_files() {
+    let (_tmp, uri) = create_many_small_fragments(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    // Soft-delete one row from each fragment (id=1 from frag 0, id=4 from
+    // frag 1) so each fragment ends up with a deletion file to materialize.
+    let pred = c_str("id = 1 OR id = 4");
+    let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), ptr::null_mut()) };
+    assert_eq!(rc, 0);
+    assert_eq!(unsafe { lance_dataset_fragment_count(ds) }, 2);
+
+    let mut metrics = LanceCompactionMetrics::default();
+    let rc = unsafe { lance_dataset_compact_files(ds, ptr::null(), &mut metrics) };
+    assert_eq!(rc, 0);
+    // Both small fragments are rewritten into a single one with the deleted
+    // rows physically removed and the deletion files gone.
+    assert_eq!(metrics.fragments_removed, 2);
+    assert_eq!(metrics.fragments_added, 1);
+    assert!(
+        metrics.files_removed >= 4,
+        "expected ≥ 2 data files + 2 deletion files removed, got {}",
+        metrics.files_removed
+    );
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 4);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_compact_target_rows_per_fragment_override_accepted() {
+    let (_tmp, uri) = create_many_small_fragments(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let opts = LanceCompactionOptions {
+        target_rows_per_fragment: 100,
+        max_rows_per_group: 0,
+        max_bytes_per_file: 0,
+        num_threads: 0,
+        batch_size: 0,
+    };
+    let rc = unsafe { lance_dataset_compact_files(ds, &opts, ptr::null_mut()) };
+    assert_eq!(rc, 0);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 9);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_compact_num_threads_override_accepted() {
+    let (_tmp, uri) = create_many_small_fragments(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let opts = LanceCompactionOptions {
+        target_rows_per_fragment: 0,
+        max_rows_per_group: 0,
+        max_bytes_per_file: 0,
+        num_threads: 1,
+        batch_size: 0,
+    };
+    let rc = unsafe { lance_dataset_compact_files(ds, &opts, ptr::null_mut()) };
+    assert_eq!(rc, 0);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 9);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_compact_max_bytes_per_file_override_accepted() {
+    // 1 MiB cap is far above what 6 rows of i32 produce, so the override
+    // just smoke-checks that the field flows through without erroring.
+    let (_tmp, uri) = create_many_small_fragments(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let opts = LanceCompactionOptions {
+        target_rows_per_fragment: 0,
+        max_rows_per_group: 0,
+        max_bytes_per_file: 1 << 20,
+        num_threads: 0,
+        batch_size: 0,
+    };
+    let rc = unsafe { lance_dataset_compact_files(ds, &opts, ptr::null_mut()) };
+    assert_eq!(rc, 0);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 6);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_compact_batch_size_and_max_rows_per_group_overrides_accepted() {
+    // Smoke-checks that the two least-observable overrides flow through
+    // without erroring; the resulting layout isn't introspected here.
+    let (_tmp, uri) = create_many_small_fragments(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let opts = LanceCompactionOptions {
+        target_rows_per_fragment: 0,
+        max_rows_per_group: 4,
+        max_bytes_per_file: 0,
+        num_threads: 0,
+        batch_size: 32,
+    };
+    let rc = unsafe { lance_dataset_compact_files(ds, &opts, ptr::null_mut()) };
+    assert_eq!(rc, 0);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 6);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_compact_zero_options_equivalent_to_null() {
+    // A zero-initialized options struct must behave identically to NULL.
+    let (_tmp, uri) = create_many_small_fragments(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+
+    let opts = LanceCompactionOptions {
+        target_rows_per_fragment: 0,
+        max_rows_per_group: 0,
+        max_bytes_per_file: 0,
+        num_threads: 0,
+        batch_size: 0,
+    };
+    let mut metrics = LanceCompactionMetrics::default();
+    let rc = unsafe { lance_dataset_compact_files(ds, &opts, &mut metrics) };
+    assert_eq!(rc, 0);
+    assert_eq!(metrics.fragments_removed, 2);
+    assert_eq!(metrics.fragments_added, 1);
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 6);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_compact_out_metrics_optional() {
+    let (_tmp, uri) = create_many_small_fragments(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    // Pass NULL out_metrics — must succeed without writing anything.
+    let rc = unsafe { lance_dataset_compact_files(ds, ptr::null(), ptr::null_mut()) };
+    assert_eq!(rc, 0);
+    assert_eq!(unsafe { lance_dataset_fragment_count(ds) }, 1);
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_compact_null_dataset_rejected() {
+    let rc = unsafe { lance_dataset_compact_files(ptr::null_mut(), ptr::null(), ptr::null_mut()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+}
+
+// Locks in the documented contract: when the call fails, `out_metrics` must
+// be left unchanged. A future refactor that pre-zeroes the slot before
+// validating inputs would silently break this guarantee.
+#[test]
+fn test_compact_out_metrics_untouched_on_error() {
+    let sentinel = LanceCompactionMetrics {
+        fragments_removed: 0xDEAD,
+        fragments_added: 0xBEEF,
+        files_removed: 0xCAFE,
+        files_added: 0xF00D,
+    };
+    let mut out = sentinel;
+    let rc = unsafe { lance_dataset_compact_files(ptr::null_mut(), ptr::null(), &mut out) };
+    assert_eq!(rc, -1);
+    assert_eq!(out, sentinel, "out slot must be untouched on error");
+}

--- a/tests/cpp/test_c_api.c
+++ b/tests/cpp/test_c_api.c
@@ -346,6 +346,36 @@ static void test_merge_insert(const char *write_uri) {
 }
 
 /* Re-opens the dataset just written by `test_dataset_write_roundtrip` and
+ * exercises `lance_dataset_compact_files`. The smoke fixture is a single
+ * fragment, so the default planner has nothing to compact — we expect
+ * all-zero metrics and no version bump. Must run before `test_delete`. */
+static void test_compact_files(const char *write_uri) {
+    printf("  test_compact_files... ");
+
+    LanceDataset *ds = lance_dataset_open(write_uri, NULL, 0);
+    ASSERT(ds != NULL, "open failed");
+    uint64_t v_before = lance_dataset_version(ds);
+
+    LanceCompactionMetrics metrics;
+    memset(&metrics, 0, sizeof(metrics));
+    int32_t rc = lance_dataset_compact_files(ds, NULL, &metrics);
+    ASSERT(rc == 0, "compact_files failed");
+    ASSERT(metrics.fragments_removed == 0 && metrics.fragments_added == 0,
+           "expected no-op metrics on a clean single-fragment dataset");
+    ASSERT(lance_dataset_version(ds) == v_before,
+           "no-op compaction must not bump the version");
+
+    /* NULL dataset must be rejected with INVALID_ARGUMENT. */
+    rc = lance_dataset_compact_files(NULL, NULL, NULL);
+    ASSERT(rc == -1, "NULL dataset must fail");
+    ASSERT(lance_last_error_code() == LANCE_ERR_INVALID_ARGUMENT,
+           "expected INVALID_ARGUMENT");
+
+    lance_dataset_close(ds);
+    printf("OK\n");
+}
+
+/* Re-opens the dataset just written by `test_dataset_write_roundtrip` and
  * exercises `lance_dataset_delete`. Must run after the write roundtrip. */
 static void test_delete(const char *write_uri) {
     printf("  test_delete... ");
@@ -393,6 +423,7 @@ int main(int argc, char **argv) {
     test_dataset_write_roundtrip(uri, write_uri);
     test_update(write_uri);
     test_merge_insert(write_uri);
+    test_compact_files(write_uri);
     test_delete(write_uri);
 
     printf("All C tests passed!\n");

--- a/tests/cpp/test_cpp_api.cpp
+++ b/tests/cpp/test_cpp_api.cpp
@@ -368,6 +368,24 @@ static void test_merge_insert(const std::string& dst_uri) {
 }
 
 // Re-opens the dataset just written by `test_dataset_write_roundtrip` and
+// exercises `Dataset::compact_files`. The smoke fixture is a single fragment
+// so the default planner has nothing to compact — we expect a no-op (zero
+// metrics, no version bump). Must run before `test_delete_rows`.
+static void test_compact_files(const std::string& dst_uri) {
+    TEST(test_compact_files);
+
+    auto ds = lance::Dataset::open(dst_uri);
+    uint64_t v_before = ds.version();
+
+    auto metrics = ds.compact_files();
+    assert(metrics.fragments_removed == 0);
+    assert(metrics.fragments_added == 0);
+    assert(ds.version() == v_before);
+
+    PASS();
+}
+
+// Re-opens the dataset just written by `test_dataset_write_roundtrip` and
 // exercises `Dataset::delete_rows`. Must run after the write roundtrip.
 static void test_delete_rows(const std::string& dst_uri) {
     TEST(test_delete_rows);
@@ -419,6 +437,7 @@ int main(int argc, char** argv) {
     test_dataset_write_roundtrip(uri, write_uri);
     test_update(write_uri);
     test_merge_insert(write_uri);
+    test_compact_files(write_uri);
     test_delete_rows(write_uri);
 
     printf("All C++ tests passed!\n");


### PR DESCRIPTION
## Summary

Adds `lance_dataset_compact_files`, exposing upstream's `compact_files` so callers can merge small fragments and materialize pending deletion files in one pass. It's the operational follow-on to `_delete` / `_update` / `_merge_insert`: heavy mutation users accumulate small fragments and deletion files, and this is the cleanup step.

A clean dataset (no fragment under the target size, no deletions worth materializing) is a no-op — the call succeeds with all-zero metrics and the version is unchanged.

## Surface

`LanceCompactionOptions` carries the five common numeric knobs:

| field | upstream default |
|---|---|
| `target_rows_per_fragment` | ~1Mi rows |
| `max_rows_per_group` | 1024 |
| `max_bytes_per_file` | writer cap |
| `num_threads` | num compute-intensive CPUs |
| `batch_size` | scanner default |

Each uses `0` to mean "keep the upstream default", so `NULL` and a zero-initialized struct behave identically. Non-zero values go through a `usize` range check so the API doesn't silently truncate on 32-bit hosts.

`LanceCompactionMetrics` mirrors upstream's four counts: `fragments_removed`, `fragments_added`, `files_removed`, `files_added`.

The C++ surface is just `Dataset::compact_files(options=nullptr)`.

## Out of scope

The knobs that don't fit the 0-sentinel convention: `materialize_deletions` (bool, default `true`), `materialize_deletions_threshold` (f32, default `0.1`), `compaction_mode` (3-variant enum), and the niche `defer_index_remap` / `binary_copy_read_batch_bytes` / `max_source_fragments` / `transaction_properties` fields. The struct is `repr(C)` and grows by appending, so any of these can land in a later PR without breaking existing callers. The `remap_options` argument to upstream is fixed at `None` for now (uses the default remapper).

## Test plan

- 12 Rust integration tests: basic merge of small neighbors, data round-trip, no-op on a clean single fragment, deletion-file materialization after a partial-row delete on each fragment, each of the five numeric overrides flowing through, zero-init/NULL equivalence, optional `out_metrics`, NULL-dataset rejection, and untouched-on-error semantics.
- C and C++ smoke tests in `compile_and_run_test` exercise the no-op path on the existing single-fragment fixture; the C side also pins the NULL-dataset rejection.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, the full Rust test suite, and the C/C++ smoke compile are green locally.