### PR TITLE
fix(cmake): add IOKit framework to APPLE link line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(LanceC_platform_deps INTERFACE)
 if(APPLE)
     target_link_libraries(LanceC_platform_deps INTERFACE
         "-framework CoreFoundation"
+        "-framework IOKit"
         "-framework Security"
         "-framework SystemConfiguration")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -146,7 +147,7 @@ install(FILES
 # ─── pkg-config ──────────────────────────────────────────────────────────────
 if(APPLE)
     set(LANCE_C_PC_LIBS_PRIVATE
-        "-framework CoreFoundation -framework Security -framework SystemConfiguration")
+        "-framework CoreFoundation -framework IOKit -framework Security -framework SystemConfiguration")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(LANCE_C_PC_LIBS_PRIVATE "-lpthread -ldl -lm")
 else()

--- a/cmake/LanceCConfig.cmake.in
+++ b/cmake/LanceCConfig.cmake.in
@@ -14,6 +14,7 @@ set(_lance_c_platform_deps "")
 if(APPLE)
     list(APPEND _lance_c_platform_deps
         "-framework CoreFoundation"
+        "-framework IOKit"
         "-framework Security"
         "-framework SystemConfiguration")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")


### PR DESCRIPTION
## Summary

The macOS arm64 consumer-smoke-test job has been failing on `main` since #24 with a long list of unresolved `_IO*` symbols (`_IOObjectRelease`, `_IOServiceMatching`, `_IOHIDEventSystemClientCreate`, `_IORegistryEntryCreateCFProperty`, …) — sample run: https://github.com/lance-format/lance-c/actions/runs/26272649710.

Root cause is plumbing, not the consumer example: `sysinfo` (pulled in transitively via the lance crates) calls IOKit on macOS for disk enumeration, CPU frequency, and thermal sensors, and `objc2_io_kit` declares the binding. Cargo's `rustc-link-lib=framework=IOKit` is honored when this repo builds, but a downstream consumer linking against the installed `liblance_c.a` via `find_package(LanceC)` (or pkg-config) only sees the frameworks we declare in our config files — and IOKit was missing.

Add `-framework IOKit` next to the existing `CoreFoundation` / `Security` / `SystemConfiguration` entries in all three mirroring places:

- `CMakeLists.txt` — build-tree `LanceC_platform_deps` interface library
- `cmake/LanceCConfig.cmake.in` — installed `find_package(LanceC)` consumers
- `CMakeLists.txt` — pkg-config `Libs.private`

## Verification

Same `cmake --install` → `examples/cmake-consumer` build path the CI runs, on arm64 macOS (15.0 SDK, AppleClang 17):

```
$ cmake --install build --prefix _install
$ cmake -S examples/cmake-consumer -B consumer-build -DCMAKE_PREFIX_PATH="$PWD/_install"
$ cmake --build consumer-build
…
[100%] Built target consumer
$ consumer-build/consumer
usage: consumer <dataset_uri>
$ echo $?
2
```

Before the patch the same sequence dies at link with `Undefined symbols for architecture arm64`. After it, the link succeeds and the binary exits 2 (usage error) as the CI step expects.

## After this lands

Unblocks the consumer-smoke macOS leg for every open PR — #42 (schema-evolution drop_columns) hits this exact failure on its CI run.