### PR TITLE
feat: add lance_dataset_alter_columns for rename / nullability / type changes

### DIFF
--- a/include/lance/lance.h
+++ b/include/lance/lance.h
@@ -484,6 +484,81 @@ int32_t lance_dataset_drop_columns(
     size_t num_columns
 );
 
+/* ─── lance_dataset_alter_columns ─────────────────────────────────────────── */
+
+/**
+ * Tri-state nullability override for `LanceColumnAlteration`. The
+ * `UNCHANGED` discriminant is zero so a zero-initialised
+ * `LanceColumnAlteration` leaves nullability alone by default.
+ *
+ * Discriminants are pinned for ABI stability. Out-of-range values are
+ * rejected with `LANCE_ERR_INVALID_ARGUMENT` — that's why the field on
+ * `LanceColumnAlteration` is `int32_t`, not this enum directly.
+ */
+typedef enum {
+    /* Do not touch the column's existing nullability. */
+    LANCE_COLUMN_NULLABLE_UNCHANGED = 0,
+    /* Set the column to nullable. */
+    LANCE_COLUMN_NULLABLE_TRUE      = 1,
+    /* Set the column to non-nullable. Upstream verifies via a scan that no
+       row holds a NULL — the call fails if any do. */
+    LANCE_COLUMN_NULLABLE_FALSE     = 2,
+} LanceColumnNullableMode;
+
+/**
+ * A single alteration applied to one column. Every non-`path` field is
+ * optional via a sentinel:
+ *
+ *   - `rename = NULL` keeps the current name.
+ *   - `nullable_mode = LANCE_COLUMN_NULLABLE_UNCHANGED` keeps current nullability.
+ *   - `data_type = NULL` keeps the current data type.
+ *
+ * At least one of `rename`, `nullable_mode`, or `data_type` must request a
+ * change; an alteration that touches nothing is rejected at the FFI boundary.
+ *
+ * `data_type`, when non-NULL, borrows an Arrow C Data Interface `ArrowSchema`
+ * describing the target type. The struct is read by shared reference for the
+ * duration of the call; its `release` callback is never invoked.
+ */
+typedef struct LanceColumnAlteration {
+    /* Path to the existing column. Required, non-empty UTF-8. */
+    const char* path;
+    /* New column name, or NULL to keep the current name. */
+    const char* rename;
+    /* LanceColumnNullableMode discriminant. */
+    int32_t     nullable_mode;
+    /* New data type, or NULL to keep the current type. */
+    const struct ArrowSchema* data_type;
+} LanceColumnAlteration;
+
+/**
+ * Apply one or more column alterations and commit a new manifest. Rename and
+ * nullability-only changes are zero-copy and preserve any indices on the
+ * affected columns. A type change rewrites the column's data files and drops
+ * any indices that referenced it, mirroring upstream behaviour.
+ *
+ * Mutates `dataset` in place — the same handle remains valid afterward and
+ * sees the new version. Scanners already in flight against this dataset keep
+ * their pre-alteration view.
+ *
+ * @param dataset          Open dataset (not consumed). Mutated in place to
+ *                         see the new version. Must not be NULL.
+ * @param alterations      Array of `LanceColumnAlteration`. Must not be NULL.
+ * @param num_alterations  Length of `alterations`. Must be > 0.
+ * @return 0 on success, -1 on error. Error codes:
+ *         LANCE_ERR_INVALID_ARGUMENT for NULL/empty inputs, NULL or empty
+ *         `path`, non-UTF-8 strings, no-op alterations (all three optional
+ *         fields left at their sentinels), invalid `nullable_mode`
+ *         discriminant, unknown columns, type changes that aren't a valid
+ *         cast, or tightening nullability when existing rows hold NULLs;
+ *         LANCE_ERR_COMMIT_CONFLICT for a concurrent writer.
+ */
+int32_t lance_dataset_alter_columns(
+    LanceDataset* dataset,
+    const LanceColumnAlteration* alterations,
+    size_t num_alterations
+);
+
 /**
  * Export the dataset schema via Arrow C Data Interface.
  * @param out  Pointer to caller-allocated ArrowSchema struct

--- a/include/lance/lance.hpp
+++ b/include/lance/lance.hpp
@@ -121,6 +121,21 @@ struct WriteParams {
     bool                       enable_stable_row_ids = false;
 };
 
+// ─── Column alteration ───────────────────────────────────────────────────────
+
+/// A single alteration applied to one column by `Dataset::alter_columns`.
+/// Every non-`path` field is optional; at least one must request a change.
+///
+/// `data_type`, when non-null, borrows an Arrow C Data Interface `ArrowSchema`
+/// describing the target type. The caller owns it and must keep it alive for
+/// the duration of the `alter_columns` call; the wrapper does not release it.
+struct ColumnAlteration {
+    std::string                path;
+    std::optional<std::string> rename;
+    LanceColumnNullableMode    nullable_mode = LANCE_COLUMN_NULLABLE_UNCHANGED;
+    const ArrowSchema*         data_type     = nullptr;
+};
+
 // ─── Dataset ─────────────────────────────────────────────────────────────────
 
 class Dataset {
@@ -459,6 +474,39 @@ public:
         // message rather than the misleading "columns must not be NULL".
         if (lance_dataset_drop_columns(
                 handle_.get(), col_ptrs.data(), columns.size()) != 0) {
+            check_error();
+        }
+    }
+
+    /// Apply one or more column alterations (rename / nullability / type
+    /// change) and commit a new manifest. Rename and nullability-only
+    /// changes are zero-copy and preserve any indices on the affected
+    /// columns; a type change rewrites the column's data files and drops
+    /// any indices that referenced it.
+    ///
+    /// `alterations` must be non-empty and each entry must request at least
+    /// one change. Any `data_type` pointer must remain valid for the
+    /// duration of this call. Throws lance::Error on failure (empty list,
+    /// no-op alteration, unknown column, incompatible cast, tightening
+    /// nullability when NULLs exist, commit conflict, ...).
+    void alter_columns(const std::vector<ColumnAlteration>& alterations) {
+        // The C strings we install in each entry borrow from `alterations`
+        // (the caller's std::strings), which outlive this call. The entries
+        // themselves are copied by value into `raw`, so any reallocation
+        // during push_back just moves the raw bytes — pointer values are
+        // preserved. `reserve` is a performance hint, not a lifetime guard.
+        std::vector<LanceColumnAlteration> raw;
+        raw.reserve(alterations.size());
+        for (const auto& a : alterations) {
+            LanceColumnAlteration entry{};
+            entry.path          = a.path.c_str();
+            entry.rename        = a.rename ? a.rename->c_str() : nullptr;
+            entry.nullable_mode = static_cast<int32_t>(a.nullable_mode);
+            entry.data_type     = a.data_type;
+            raw.push_back(entry);
+        }
+        if (lance_dataset_alter_columns(
+                handle_.get(), raw.data(), raw.size()) != 0) {
             check_error();
         }
     }

--- a/src/alter_columns.rs
+++ b/src/alter_columns.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Alter columns C API: rename a column, change its nullability, or change its
+//! data type, committing a new manifest. Rename and nullability-only changes
+//! are zero-copy and preserve indices; a type change rewrites the column's
+//! data files and drops any associated indices, mirroring upstream behaviour.
+//!
+//! Mutates the dataset in place under an exclusive write lock; existing
+//! scanners that already cloned the inner Arc keep their pre-alteration view.
+
+use std::ffi::c_char;
+
+use arrow::ffi::FFI_ArrowSchema;
+use arrow_schema::DataType;
+use lance::dataset::ColumnAlteration;
+use lance_core::Result;
+use snafu::location;
+
+use crate::dataset::LanceDataset;
+use crate::error::ffi_try;
+use crate::helpers;
+use crate::runtime::block_on;
+
+/// Tri-state nullability override for `LanceColumnAlteration`. The `Unchanged`
+/// discriminant is zero so a zero-initialised struct leaves nullability alone.
+///
+/// Discriminants are pinned for ABI stability. Out-of-range values stored on
+/// the FFI side are rejected with `LANCE_ERR_INVALID_ARGUMENT` rather than
+/// being transmuted into a `repr(C)` enum (which would be UB) — that's why
+/// the corresponding field on `LanceColumnAlteration` is `i32`, not this
+/// enum directly.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LanceColumnNullableMode {
+    /// Do not touch the column's existing nullability.
+    Unchanged = 0,
+    /// Set the column to nullable.
+    True = 1,
+    /// Set the column to non-nullable. Upstream verifies via a scan that no
+    /// existing rows hold a NULL — the call fails if any do.
+    False = 2,
+}
+
+impl LanceColumnNullableMode {
+    fn from_raw(raw: i32) -> Result<Self> {
+        match raw {
+            0 => Ok(Self::Unchanged),
+            1 => Ok(Self::True),
+            2 => Ok(Self::False),
+            other => Err(lance_core::Error::InvalidInput {
+                source: format!(
+                    "invalid nullable_mode {other}; expected 0..=2 (see LanceColumnNullableMode)"
+                )
+                .into(),
+                location: location!(),
+            }),
+        }
+    }
+}
+
+/// A single alteration applied to one column. Each non-`path` field is
+/// optional via a sentinel:
+///
+/// * `rename = NULL` keeps the current name.
+/// * `nullable_mode = LANCE_COLUMN_NULLABLE_UNCHANGED` keeps the current
+///   nullability.
+/// * `data_type = NULL` keeps the current data type.
+///
+/// At least one of `rename`, `nullable_mode`, or `data_type` must request a
+/// change; an alteration that touches nothing is rejected at the FFI
+/// boundary.
+///
+/// `data_type` borrows an Arrow C Data Interface `ArrowSchema` describing the
+/// target type for the duration of the call. The struct is read by shared
+/// reference; we never call its `release` callback.
+#[repr(C)]
+pub struct LanceColumnAlteration {
+    /// Path to the existing column to alter. Required, non-empty UTF-8.
+    pub path: *const c_char,
+    /// New column name, or NULL to keep the current name.
+    pub rename: *const c_char,
+    /// `LanceColumnNullableMode` discriminant; carried as `i32` so an
+    /// invalid value coming in from C is rejected at the FFI boundary
+    /// instead of being transmuted into an enum (which would be UB).
+    pub nullable_mode: i32,
+    /// New data type, or NULL to keep the current type.
+    pub data_type: *const FFI_ArrowSchema,
+}
+
+/// Apply one or more `LanceColumnAlteration`s and commit a new manifest.
+/// Rename and nullability-only changes are zero-copy and preserve any indices
+/// on the affected columns. A type change rewrites the column's data files
+/// and drops any indices that referenced it.
+///
+/// - `dataset`: Open dataset (mutated; same handle remains valid afterward).
+///   Must not be NULL.
+/// - `alterations`: Pointer to an array of `LanceColumnAlteration`. Must not
+///   be NULL.
+/// - `num_alterations`: Length of the `alterations` array. Must be non-zero.
+///
+/// Returns 0 on success, -1 on error. Error codes:
+/// `LANCE_ERR_INVALID_ARGUMENT` for NULL/empty args, NULL or empty `path`,
+/// non-UTF-8 strings, no-op alterations (all three optional fields left at
+/// their sentinels), invalid `nullable_mode` discriminant, unknown columns,
+/// type changes that aren't a valid cast, or tightening nullability when
+/// existing rows hold NULLs. `LANCE_ERR_COMMIT_CONFLICT` for a concurrent
+/// writer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn lance_dataset_alter_columns(
+    dataset: *mut LanceDataset,
+    alterations: *const LanceColumnAlteration,
+    num_alterations: usize,
+) -> i32 {
+    ffi_try!(
+        unsafe { alter_columns_inner(dataset, alterations, num_alterations) },
+        neg
+    )
+}
+
+unsafe fn alter_columns_inner(
+    dataset: *mut LanceDataset,
+    alterations: *const LanceColumnAlteration,
+    num_alterations: usize,
+) -> Result<i32> {
+    if dataset.is_null() {
+        return Err(lance_core::Error::InvalidInput {
+            source: "dataset must not be NULL".into(),
+            location: location!(),
+        });
+    }
+    if alterations.is_null() {
+        return Err(lance_core::Error::InvalidInput {
+            source: "alterations must not be NULL".into(),
+            location: location!(),
+        });
+    }
+    if num_alterations == 0 {
+        return Err(lance_core::Error::InvalidInput {
+            source: "num_alterations must be > 0".into(),
+            location: location!(),
+        });
+    }
+
+    // Materialize alterations up front so any per-index validation error
+    // fires before the dataset's write lock is taken — matches the pre-lock
+    // validation pattern used by `update.rs` and `drop_columns.rs`.
+    let mut owned: Vec<ColumnAlteration> = Vec::with_capacity(num_alterations);
+    for i in 0..num_alterations {
+        // SAFETY: `alterations` is non-NULL (checked above) and the caller
+        // guarantees the array has at least `num_alterations` initialised
+        // entries valid for the duration of this call. `parse_alteration`
+        // is `unsafe` solely because it dereferences each entry's `path` /
+        // `rename` / `data_type` pointers — same caller-side guarantee.
+        let entry = unsafe { &*alterations.add(i) };
+        owned.push(unsafe { parse_alteration(i, entry)? });
+    }
+
+    // SAFETY: `dataset` is non-NULL (checked above) and the caller guarantees
+    // it points to a live `LanceDataset`. `with_mut` takes an exclusive
+    // write lock on the inner `Arc<Dataset>` before yielding `&mut Dataset`,
+    // so a shared `&*dataset` borrow here is sound — interior mutability is
+    // the synchronization point.
+    let ds = unsafe { &*dataset };
+    ds.with_mut(|d| block_on(d.alter_columns(&owned)))?;
+    Ok(0)
+}
+
+/// Translate one C-side `LanceColumnAlteration` into the upstream owned form,
+/// validating every field at the FFI boundary so the caller sees precise
+/// per-index errors rather than upstream-internal ones.
+unsafe fn parse_alteration(
+    index: usize,
+    entry: &LanceColumnAlteration,
+) -> Result<ColumnAlteration> {
+    // SAFETY: `entry.path` is either NULL (rejected below) or a NUL-terminated
+    // C string the caller keeps alive for this call.
+    let path = unsafe { helpers::parse_c_string(entry.path)? }
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| lance_core::Error::InvalidInput {
+            source: format!("alterations[{index}].path must not be NULL or empty").into(),
+            location: location!(),
+        })?
+        .to_string();
+
+    // SAFETY: same shape as `path`; NULL is a documented sentinel for "keep
+    // the current name", not an error.
+    let rename = unsafe { helpers::parse_c_string(entry.rename)? }
+        .map(|s| {
+            if s.is_empty() {
+                Err(lance_core::Error::InvalidInput {
+                    source: format!("alterations[{index}].rename must not be empty").into(),
+                    location: location!(),
+                })
+            } else {
+                Ok(s.to_string())
+            }
+        })
+        .transpose()?;
+
+    let nullable = match LanceColumnNullableMode::from_raw(entry.nullable_mode)? {
+        LanceColumnNullableMode::Unchanged => None,
+        LanceColumnNullableMode::True => Some(true),
+        LanceColumnNullableMode::False => Some(false),
+    };
+
+    let data_type = if entry.data_type.is_null() {
+        None
+    } else {
+        // SAFETY: caller guarantees `data_type` (when non-NULL) points to a
+        // valid `FFI_ArrowSchema` for the duration of this call. We read by
+        // shared reference and never invoke the struct's release callback.
+        let ffi_schema = unsafe { &*entry.data_type };
+        // Reject an already-released or never-initialised schema before
+        // handing it to arrow-rs, which would otherwise `assert!` on the
+        // NULL `format` field and abort the host process under our
+        // `panic = "abort"` profile. Both checks are intentional:
+        //   - `release == NULL`: the canonical Arrow CADI "released" sentinel.
+        //   - `format == NULL`: catches a zero-initialised or otherwise
+        //     half-built struct that would slip past the release check.
+        if ffi_schema.release.is_none() || ffi_schema.format.is_null() {
+            return Err(lance_core::Error::InvalidInput {
+                source: format!(
+                    "alterations[{index}].data_type is uninitialised or already released"
+                )
+                .into(),
+                location: location!(),
+            });
+        }
+        let dt = DataType::try_from(ffi_schema).map_err(|e| lance_core::Error::InvalidInput {
+            source: format!("alterations[{index}].data_type is not a valid Arrow type: {e}").into(),
+            location: location!(),
+        })?;
+        Some(dt)
+    };
+
+    if rename.is_none() && nullable.is_none() && data_type.is_none() {
+        return Err(lance_core::Error::InvalidInput {
+            source: format!(
+                "alterations[{index}] is a no-op: \
+                 set rename, nullable_mode, or data_type to request a change"
+            )
+            .into(),
+            location: location!(),
+        });
+    }
+
+    Ok(ColumnAlteration {
+        path,
+        rename,
+        nullable,
+        data_type,
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 //! - The caller is responsible for freeing returned strings with `lance_free_string()`.
 #![allow(clippy::missing_safety_doc)]
 
+mod alter_columns;
 mod async_dispatcher;
 mod batch;
 mod compact;
@@ -34,6 +35,7 @@ mod versions;
 mod writer;
 
 // Re-export all extern "C" symbols so they appear in the cdylib.
+pub use alter_columns::*;
 pub use batch::*;
 pub use compact::*;
 pub use dataset::*;

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -98,6 +98,32 @@ fn c_str(s: &str) -> CString {
     CString::new(s).unwrap()
 }
 
+/// Helper: build a tiny dataset whose `value` column is nullable AND contains
+/// at least one NULL. Used by tests that need to exercise upstream's
+/// nullability-tightening pre-scan failure path.
+fn create_dataset_with_nulls() -> (tempfile::TempDir, String) {
+    let tmp = tempfile::tempdir().unwrap();
+    let uri = tmp.path().join("with_nulls").to_str().unwrap().to_string();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("value", DataType::Float32, true),
+    ]));
+    let ids = Int32Array::from(vec![1, 2, 3]);
+    let values = Float32Array::from(vec![Some(1.0), None, Some(3.0)]);
+    let batch =
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(values)]).unwrap();
+    lance_c::runtime::block_on(async {
+        Dataset::write(
+            arrow::record_batch::RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &uri,
+            None,
+        )
+        .await
+        .unwrap();
+    });
+    (tmp, uri)
+}
+
 /// Helper: scan to ArrowArrayStream and collect all rows.
 fn scan_all_rows(ds: *const LanceDataset) -> Vec<RecordBatch> {
     let scanner = unsafe { lance_scanner_new(ds, ptr::null(), ptr::null()) };
@@ -6533,6 +6559,534 @@ fn test_drop_columns_empty_entry_rejected() {
     assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
     let names = schema_field_names(ds);
     assert_eq!(names, vec!["id", "value", "label"]);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+// ===========================================================================
+// lance_dataset_alter_columns
+// ===========================================================================
+
+/// Build an FFI ArrowSchema describing a single field of the given Arrow
+/// `DataType`. The returned struct owns its memory; the caller must keep it
+/// alive for the duration of any `lance_dataset_alter_columns` call that
+/// references it via `LanceColumnAlteration::data_type`. The placeholder
+/// field name is never inspected by the alter path — only the `format`
+/// string (i.e. the data type) is read out via `DataType::try_from`.
+fn ffi_schema_for(data_type: DataType) -> FFI_ArrowSchema {
+    let field = arrow_schema::Field::new("_", data_type, true);
+    FFI_ArrowSchema::try_from(&field).expect("Field -> FFI_ArrowSchema")
+}
+
+/// Convenience: build a `LanceColumnAlteration` with all-default sentinels.
+fn default_alteration(path: *const c_char) -> LanceColumnAlteration {
+    LanceColumnAlteration {
+        path,
+        rename: ptr::null(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: ptr::null(),
+    }
+}
+
+#[test]
+fn test_alter_columns_rename_only() {
+    let (_tmp, uri) = create_large_dataset(4);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let path = c_str("label");
+    let rename = c_str("tag");
+    let alt = LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: rename.as_ptr(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: ptr::null(),
+    };
+    let alts = [alt];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, 0);
+
+    let names = schema_field_names(ds);
+    assert_eq!(names, vec!["id", "value", "tag"]);
+    // Metadata-only rename preserves row count.
+    assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 4);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_relax_nullability() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    // `id` is non-nullable in the fixture; relax it to nullable.
+    let path = c_str("id");
+    let alt = LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: ptr::null(),
+        nullable_mode: LanceColumnNullableMode::True as i32,
+        data_type: ptr::null(),
+    };
+    let alts = [alt];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, 0);
+
+    let mut ffi_schema = FFI_ArrowSchema::empty();
+    let rc = unsafe { lance_dataset_schema(ds, &mut ffi_schema) };
+    assert_eq!(rc, 0);
+    let arrow_schema = arrow_schema::Schema::try_from(&ffi_schema).unwrap();
+    let id_field = arrow_schema.field_with_name("id").unwrap();
+    assert!(id_field.is_nullable(), "id should be nullable after alter");
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_tighten_nullability_no_nulls() {
+    let (_tmp, uri) = create_large_dataset(3);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    // `label` is nullable in the fixture but no rows hold a NULL, so
+    // tightening to non-nullable should succeed.
+    let path = c_str("label");
+    let alt = LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: ptr::null(),
+        nullable_mode: LanceColumnNullableMode::False as i32,
+        data_type: ptr::null(),
+    };
+    let alts = [alt];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, 0);
+
+    let mut ffi_schema = FFI_ArrowSchema::empty();
+    let rc = unsafe { lance_dataset_schema(ds, &mut ffi_schema) };
+    assert_eq!(rc, 0);
+    let arrow_schema = arrow_schema::Schema::try_from(&ffi_schema).unwrap();
+    let label_field = arrow_schema.field_with_name("label").unwrap();
+    assert!(
+        !label_field.is_nullable(),
+        "label should be non-nullable after tightening"
+    );
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_type_change_int32_to_int64() {
+    let (_tmp, uri) = create_large_dataset(4);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    // `id` is Int32 in the fixture; upcast to Int64.
+    let new_type = ffi_schema_for(DataType::Int64);
+    let path = c_str("id");
+    let alt = LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: ptr::null(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: &new_type as *const _,
+    };
+    let alts = [alt];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, 0);
+
+    let mut ffi_schema = FFI_ArrowSchema::empty();
+    let rc = unsafe { lance_dataset_schema(ds, &mut ffi_schema) };
+    assert_eq!(rc, 0);
+    let arrow_schema = arrow_schema::Schema::try_from(&ffi_schema).unwrap();
+    let id_field = arrow_schema.field_with_name("id").unwrap();
+    assert_eq!(id_field.data_type(), &DataType::Int64);
+
+    // Data is preserved (and now Int64-typed).
+    let indices: [u64; 4] = [0, 1, 2, 3];
+    let mut stream = FFI_ArrowArrayStream::empty();
+    let rc = unsafe {
+        lance_dataset_take(
+            ds,
+            indices.as_ptr(),
+            indices.len(),
+            ptr::null(),
+            &mut stream,
+        )
+    };
+    assert_eq!(rc, 0);
+    let reader = unsafe { ArrowArrayStreamReader::from_raw(&mut stream) }.unwrap();
+    let batches: Vec<_> = reader.into_iter().collect::<Result<Vec<_>, _>>().unwrap();
+    let mut ids: Vec<i64> = Vec::new();
+    for b in &batches {
+        let col = b
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<arrow_array::Int64Array>()
+            .unwrap();
+        for i in 0..b.num_rows() {
+            ids.push(col.value(i));
+        }
+    }
+    assert_eq!(ids, vec![0i64, 1, 2, 3]);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_rename_and_relax_nullable_combined() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let path = c_str("id");
+    let rename = c_str("row_id");
+    let alt = LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: rename.as_ptr(),
+        nullable_mode: LanceColumnNullableMode::True as i32,
+        data_type: ptr::null(),
+    };
+    let alts = [alt];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, 0);
+
+    let mut ffi_schema = FFI_ArrowSchema::empty();
+    let rc = unsafe { lance_dataset_schema(ds, &mut ffi_schema) };
+    assert_eq!(rc, 0);
+    let arrow_schema = arrow_schema::Schema::try_from(&ffi_schema).unwrap();
+    let renamed = arrow_schema.field_with_name("row_id").unwrap();
+    assert!(renamed.is_nullable());
+    assert!(arrow_schema.field_with_name("id").is_err());
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_multiple_per_call() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let p1 = c_str("value");
+    let r1 = c_str("val");
+    let p2 = c_str("label");
+    let r2 = c_str("tag");
+    let alts = [
+        LanceColumnAlteration {
+            path: p1.as_ptr(),
+            rename: r1.as_ptr(),
+            nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+            data_type: ptr::null(),
+        },
+        LanceColumnAlteration {
+            path: p2.as_ptr(),
+            rename: r2.as_ptr(),
+            nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+            data_type: ptr::null(),
+        },
+    ];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, 0);
+
+    let names = schema_field_names(ds);
+    assert_eq!(names, vec!["id", "val", "tag"]);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_bumps_version() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let v_before = unsafe { lance_dataset_version(ds) };
+    let path = c_str("label");
+    let rename = c_str("tag");
+    let alt = LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: rename.as_ptr(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: ptr::null(),
+    };
+    let alts = [alt];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, 0);
+    let v_after = unsafe { lance_dataset_version(ds) };
+    assert!(
+        v_after > v_before,
+        "version should increase: before={v_before}, after={v_after}"
+    );
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_unknown_column_rejected() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let path = c_str("no_such_column");
+    let rename = c_str("whatever");
+    let alt = LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: rename.as_ptr(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: ptr::null(),
+    };
+    let alts = [alt];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+    // Dataset is untouched on the error path.
+    let names = schema_field_names(ds);
+    assert_eq!(names, vec!["id", "value", "label"]);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_type_change_incompatible_rejected() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    // Int32 -> Utf8 is not a valid Arrow upcast/downcast — upstream rejects.
+    let new_type = ffi_schema_for(DataType::Utf8);
+    let path = c_str("id");
+    let alt = LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: ptr::null(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: &new_type as *const _,
+    };
+    let alts = [alt];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_noop_alteration_rejected() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let path = c_str("id");
+    let v_before = unsafe { lance_dataset_version(ds) };
+    let alts = [default_alteration(path.as_ptr())];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+    // No version bump and no schema change on the error path.
+    assert_eq!(unsafe { lance_dataset_version(ds) }, v_before);
+    assert_eq!(schema_field_names(ds), vec!["id", "value", "label"]);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_null_dataset_rejected() {
+    let path = c_str("id");
+    let rename = c_str("row_id");
+    let alts = [LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: rename.as_ptr(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: ptr::null(),
+    }];
+    let rc = unsafe { lance_dataset_alter_columns(ptr::null_mut(), alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+}
+
+#[test]
+fn test_alter_columns_null_alterations_rejected() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let rc = unsafe { lance_dataset_alter_columns(ds, ptr::null(), 1) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_zero_count_rejected() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let path = c_str("id");
+    let rename = c_str("row_id");
+    let alts = [LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: rename.as_ptr(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: ptr::null(),
+    }];
+    let v_before = unsafe { lance_dataset_version(ds) };
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), 0) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+    assert_eq!(unsafe { lance_dataset_version(ds) }, v_before);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_null_path_rejected() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let rename = c_str("whatever");
+    let alts = [LanceColumnAlteration {
+        path: ptr::null(),
+        rename: rename.as_ptr(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: ptr::null(),
+    }];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_empty_path_rejected() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let empty = c_str("");
+    let rename = c_str("whatever");
+    let alts = [LanceColumnAlteration {
+        path: empty.as_ptr(),
+        rename: rename.as_ptr(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: ptr::null(),
+    }];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_empty_rename_rejected() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    // Distinct from `rename = NULL` (which means "keep current name") — an
+    // explicit empty string is a malformed request.
+    let path = c_str("id");
+    let empty = c_str("");
+    let alts = [LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: empty.as_ptr(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: ptr::null(),
+    }];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_invalid_nullable_mode_rejected() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    // An out-of-range discriminant (e.g. 99) must be rejected at the FFI
+    // boundary rather than transmuted into the repr(C) enum. This locks in
+    // the discriminant-validation contract.
+    let path = c_str("id");
+    let alts = [LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: ptr::null(),
+        nullable_mode: 99,
+        data_type: ptr::null(),
+    }];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_released_schema_rejected() {
+    let (_tmp, uri) = create_large_dataset(2);
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    // An uninitialised / already-released `FFI_ArrowSchema` has both its
+    // `release` callback and its `format` field set to NULL. Passing it as
+    // `data_type` must surface as INVALID_ARGUMENT rather than aborting the
+    // host process via the arrow-rs `assert!(!format.is_null())`.
+    let empty_schema = FFI_ArrowSchema::empty();
+    let path = c_str("id");
+    let alts = [LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: ptr::null(),
+        nullable_mode: LanceColumnNullableMode::Unchanged as i32,
+        data_type: &empty_schema as *const _,
+    }];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+
+    unsafe { lance_dataset_close(ds) };
+}
+
+#[test]
+fn test_alter_columns_tighten_nullability_with_nulls_rejected() {
+    // The `value` column actually carries a NULL, so upstream's pre-write
+    // scan must reject the attempt to make it non-nullable.
+    let (_tmp, uri) = create_dataset_with_nulls();
+    let c_uri = c_str(&uri);
+    let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+    assert!(!ds.is_null());
+
+    let path = c_str("value");
+    let alts = [LanceColumnAlteration {
+        path: path.as_ptr(),
+        rename: ptr::null(),
+        nullable_mode: LanceColumnNullableMode::False as i32,
+        data_type: ptr::null(),
+    }];
+    let rc = unsafe { lance_dataset_alter_columns(ds, alts.as_ptr(), alts.len()) };
+    assert_eq!(rc, -1);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
 
     unsafe { lance_dataset_close(ds) };
 }

--- a/tests/cpp/test_c_api.c
+++ b/tests/cpp/test_c_api.c
@@ -16,6 +16,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Arrow C Data Interface flag bits — mirror arrow_schema/arrow_c_data_interface.h
+ * so we don't depend on the full Arrow header just to read schema flags. */
+#define ARROW_FLAG_NULLABLE 2
+
 #define ASSERT(cond, msg)                                                      \
     do {                                                                       \
         if (!(cond)) {                                                         \
@@ -346,6 +350,76 @@ static void test_merge_insert(const char *write_uri) {
 }
 
 /* Re-opens the dataset just written by `test_dataset_write_roundtrip` and
+ * exercises `lance_dataset_alter_columns` by relaxing the nullability of the
+ * `id` column (non-nullable in the fixture) to nullable. Must run before
+ * `test_drop_columns` removes `name`, but the alteration itself only touches
+ * `id`, so the column survives the subsequent drop. */
+static void test_alter_columns(const char *write_uri) {
+    printf("  test_alter_columns... ");
+
+    LanceDataset *ds = lance_dataset_open(write_uri, NULL, 0);
+    ASSERT(ds != NULL, "open failed");
+    uint64_t v_before = lance_dataset_version(ds);
+
+    LanceColumnAlteration alt = {0};
+    alt.path          = "id";
+    alt.nullable_mode = LANCE_COLUMN_NULLABLE_TRUE;
+    int32_t rc = lance_dataset_alter_columns(ds, &alt, 1);
+    ASSERT(rc == 0, "alter_columns failed");
+    ASSERT(lance_dataset_version(ds) > v_before,
+           "alter_columns must bump the version");
+
+    /* Schema export to confirm `id` is now nullable. */
+    struct ArrowSchema schema;
+    memset(&schema, 0, sizeof(schema));
+    rc = lance_dataset_schema(ds, &schema);
+    ASSERT(rc == 0, "schema export failed");
+    ASSERT(schema.n_children > 0, "schema must have children");
+    int found_nullable_id = 0;
+    for (int64_t i = 0; i < schema.n_children; i++) {
+        struct ArrowSchema *child = schema.children[i];
+        if (!child) continue;
+        if (strcmp(child->name, "id") == 0) {
+            if ((child->flags & ARROW_FLAG_NULLABLE) != 0) found_nullable_id = 1;
+        }
+    }
+    if (schema.release) schema.release(&schema);
+    ASSERT(found_nullable_id, "id should be nullable after alter");
+
+    /* NULL alterations and num_alterations == 0 must be rejected. */
+    rc = lance_dataset_alter_columns(ds, NULL, 1);
+    ASSERT(rc == -1, "NULL alterations must fail");
+    ASSERT(lance_last_error_code() == LANCE_ERR_INVALID_ARGUMENT,
+           "expected INVALID_ARGUMENT");
+
+    rc = lance_dataset_alter_columns(ds, &alt, 0);
+    ASSERT(rc == -1, "num_alterations=0 must fail");
+    ASSERT(lance_last_error_code() == LANCE_ERR_INVALID_ARGUMENT,
+           "expected INVALID_ARGUMENT");
+
+    /* No-op alteration (all sentinels left at defaults) must be rejected. */
+    LanceColumnAlteration noop = {0};
+    noop.path = "id";
+    rc = lance_dataset_alter_columns(ds, &noop, 1);
+    ASSERT(rc == -1, "no-op alteration must fail");
+    ASSERT(lance_last_error_code() == LANCE_ERR_INVALID_ARGUMENT,
+           "expected INVALID_ARGUMENT");
+
+    /* Out-of-range nullable_mode discriminant must be rejected at the FFI
+     * boundary rather than transmuted into the repr(C) enum. */
+    LanceColumnAlteration bad_mode = {0};
+    bad_mode.path = "id";
+    bad_mode.nullable_mode = 99;
+    rc = lance_dataset_alter_columns(ds, &bad_mode, 1);
+    ASSERT(rc == -1, "invalid nullable_mode must fail");
+    ASSERT(lance_last_error_code() == LANCE_ERR_INVALID_ARGUMENT,
+           "expected INVALID_ARGUMENT");
+
+    lance_dataset_close(ds);
+    printf("OK\n");
+}
+
+/* Re-opens the dataset just written by `test_dataset_write_roundtrip` and
  * exercises `lance_dataset_drop_columns`. Drops the `name` column so the
  * dataset is left with `id` only; subsequent tests (`compact_files`,
  * `delete`) do not reference any dropped column. Must run after
@@ -500,6 +574,7 @@ int main(int argc, char **argv) {
     test_dataset_write_roundtrip(uri, write_uri);
     test_update(write_uri);
     test_merge_insert(write_uri);
+    test_alter_columns(write_uri);
     test_drop_columns(write_uri);
     test_compact_files(write_uri);
     test_delete(write_uri);

--- a/tests/cpp/test_cpp_api.cpp
+++ b/tests/cpp/test_cpp_api.cpp
@@ -18,6 +18,9 @@
 #include <string>
 #include <vector>
 
+// Arrow C Data Interface flag bits — see arrow_schema/arrow_c_data_interface.h.
+#define ARROW_FLAG_NULLABLE 2
+
 #define TEST(name) printf("  %s... ", #name)
 #define PASS()     printf("OK\n")
 
@@ -398,6 +401,71 @@ static void test_merge_insert(const std::string& dst_uri) {
 }
 
 // Re-opens the dataset just written by `test_dataset_write_roundtrip` and
+// exercises `Dataset::alter_columns`. Relaxes the nullability of `id` (non-
+// nullable in the fixture) to nullable; the column survives the subsequent
+// drop_columns({"name"}) test untouched.
+static void test_alter_columns(const std::string& dst_uri) {
+    TEST(test_alter_columns);
+
+    auto ds = lance::Dataset::open(dst_uri);
+    uint64_t v_before = ds.version();
+
+    lance::ColumnAlteration alt;
+    alt.path          = "id";
+    alt.nullable_mode = LANCE_COLUMN_NULLABLE_TRUE;
+    ds.alter_columns({alt});
+    assert(ds.version() > v_before
+           && "alter_columns must bump the version");
+
+    // Confirm the schema reflects the relaxed nullability.
+    ArrowSchema schema;
+    memset(&schema, 0, sizeof(schema));
+    ds.schema(&schema);
+    assert(schema.n_children > 0 && "schema must have children");
+    bool id_is_nullable = false;
+    for (int64_t i = 0; i < schema.n_children; i++) {
+        ArrowSchema* child = schema.children[i];
+        if (!child) continue;
+        if (strcmp(child->name, "id") == 0) {
+            id_is_nullable = (child->flags & ARROW_FLAG_NULLABLE) != 0;
+        }
+    }
+    if (schema.release) schema.release(&schema);
+    assert(id_is_nullable && "id should be nullable after alter");
+
+    // No-op alteration (all sentinels left at defaults) must throw with
+    // INVALID_ARGUMENT.
+    bool caught_noop = false;
+    try {
+        lance::ColumnAlteration noop;
+        noop.path = "id";
+        ds.alter_columns({noop});
+    } catch (const lance::Error& e) {
+        caught_noop = true;
+        assert(e.code == LANCE_ERR_INVALID_ARGUMENT);
+    }
+    assert(caught_noop);
+
+    // Out-of-range nullable_mode discriminant must throw with INVALID_ARGUMENT.
+    // Cast `99` through the enum type to verify the C++ wrapper forwards it
+    // verbatim rather than silently clamping.
+    bool caught_bad_mode = false;
+    try {
+        lance::ColumnAlteration bad_mode;
+        bad_mode.path = "id";
+        bad_mode.nullable_mode =
+            static_cast<LanceColumnNullableMode>(99);
+        ds.alter_columns({bad_mode});
+    } catch (const lance::Error& e) {
+        caught_bad_mode = true;
+        assert(e.code == LANCE_ERR_INVALID_ARGUMENT);
+    }
+    assert(caught_bad_mode);
+
+    PASS();
+}
+
+// Re-opens the dataset just written by `test_dataset_write_roundtrip` and
 // exercises `Dataset::drop_columns`. Drops the `name` column so the dataset
 // is left with `id` only; subsequent tests (`compact_files`, `delete_rows`)
 // do not reference any dropped column. Must run after `test_update` /
@@ -525,6 +593,7 @@ int main(int argc, char** argv) {
     test_dataset_write_roundtrip(uri, write_uri);
     test_update(write_uri);
     test_merge_insert(write_uri);
+    test_alter_columns(write_uri);
     test_drop_columns(write_uri);
     test_compact_files(write_uri);
     test_delete_rows(write_uri);


### PR DESCRIPTION
## Summary

Second of three PRs against #41. Exposes upstream's `Dataset::alter_columns` — rename a column, change its nullability, or change its data type, committing a new manifest. Rename and nullability-only changes are zero-copy and preserve indices on the affected column; a type change rewrites the column's data files and drops any associated indices, mirroring upstream behavior.

Mutates the dataset in place under an exclusive write lock; scanners already in flight against it keep their pre-alteration view via the existing Arc clone-on-write, same as `_delete` (#31) / `_drop_columns` (#42).

## Surface

```c
typedef enum {
    LANCE_COLUMN_NULLABLE_UNCHANGED = 0,
    LANCE_COLUMN_NULLABLE_TRUE      = 1,
    LANCE_COLUMN_NULLABLE_FALSE     = 2,
} LanceColumnNullableMode;

typedef struct LanceColumnAlteration {
    const char* path;                       /* required */
    const char* rename;                     /* NULL = keep */
    int32_t     nullable_mode;              /* LanceColumnNullableMode discriminant */
    const struct ArrowSchema* data_type;    /* NULL = keep */
} LanceColumnAlteration;

int32_t lance_dataset_alter_columns(
    LanceDataset* dataset,
    const LanceColumnAlteration* alterations,
    size_t num_alterations
);
```

Per-alteration validation runs up front with index-tagged error messages. The struct uses sentinels for the three optional fields (`rename = NULL`, `nullable_mode = UNCHANGED`, `data_type = NULL`); at least one must request a change, so a zero-init struct with only `path` set is rejected as a no-op rather than silently consuming a manifest version.

Two design choices worth calling out:

- **`nullable_mode` is `int32_t`, not the enum directly.** The struct is read across the FFI boundary, and Rust treats a `#[repr(C)]` enum read from C with an out-of-range discriminant as UB. So the field is `int32_t` and a `LanceColumnNullableMode::from_raw(i32)` helper converts and returns `INVALID_ARGUMENT` for unknown values — same pattern as `merge_insert`'s `WhenMatched::from_raw`.

- **`data_type` borrows an Arrow `ArrowSchema`.** The wrapper never calls its `release` callback. Before handing the pointer to arrow-rs, the wrapper checks both `release == NULL` (the Arrow CADI "released" sentinel) and `format == NULL` (catches `FFI_ArrowSchema::empty()` and other half-built structs that would otherwise hit an `assert!` in `DataType::try_from` and abort the host process under `panic = "abort"`).

The C++ wrapper takes `const std::vector<lance::ColumnAlteration>&` and uses the same direct-pass convention as `update`/`merge_insert` siblings — `raw.data()` unconditionally; an empty vector flows through the Rust-side `num_alterations == 0` guard so the error message is precise.

## Tests

Nineteen new Rust integration tests cover the positive paths (rename, relax / tighten nullability, Int32→Int64 upcast with value round-trip, combined rename+relax, multi-alteration per call, version bump) and the full rejection surface (NULL dataset / NULL array / zero count / NULL path / empty path / empty rename / unknown column / incompatible cast / no-op alteration with schema-unchanged assertion / invalid `nullable_mode` discriminant / uninitialised `FFI_ArrowSchema` / tightening nullability when existing rows hold NULLs).

C and C++ smoke tests slot in before `test_drop_columns`, relax `id` to nullable, and verify via `ArrowSchema.flags & ARROW_FLAG_NULLABLE`. Both also exercise the NULL / zero / no-op / bad-discriminant negative paths. `cargo test` and `cargo test --test compile_and_run_test -- --ignored` both green.

## Follow-up

- `lance_dataset_add_columns` — SQL expressions / AllNulls / ArrowArrayStream

The README roadmap entry stays unticked until that lands.