### PR TITLE
docs: mark schema evolution complete in roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Based on the [liblance RFC](https://github.com/lance-format/lance/discussions/60
 | [ ] | Delete operations | Predicate-based deletion |
 | [ ] | Update operations | Expression-based row updates |
 | [ ] | Merge-insert | Upsert functionality with builder pattern |
-| [ ] | Schema evolution | Add/drop/alter columns with expressions |
+| [x] | Schema evolution | Add columns via SQL / all-null / `ArrowArrayStream` with `lance_dataset_add_columns_*()`, drop via `lance_dataset_drop_columns()`, rename / retype / set nullability via `lance_dataset_alter_columns()` |
 | [x] | Version management | List via `lance_dataset_versions()`, rollback via `lance_dataset_restore()`, checkout via `lance_dataset_open(uri, opts, version)` |
 
 ### Phase 4: Advanced Features


### PR DESCRIPTION
The schema-evolution series is fully merged, so this flips the Phase 3 roadmap row from `[ ]` to `[x]` and names the functions that cover it, matching the style of the rows around it.

Covered by:
- #45 — `lance_dataset_add_columns_sql/_nulls/_stream`
- #44 — `lance_dataset_alter_columns`
- #42 — `lance_dataset_drop_columns`

Closes #41.

Docs-only; no code or test changes.