### PR TITLE
fix(deps): bump ethnum to 1.5.3 for rustc 1.97 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"


### PR DESCRIPTION
## Problem

All three targets fail the v0.1.3 release build ([run 30955879314](https://github.com/lance-format/lance-c/actions/runs/30955879314)) at `Configure + build`:

```
error[E0512]: cannot transmute between types of different sizes
  --> ethnum-1.5.2/src/error.rs:16:14
   |
16 |     unsafe { mem::transmute(()) }
   = note: source type: `()` (0 bits)
   = note: target type: `TryFromIntError` (8 bits)
```

`ethnum` 1.5.2 fabricates a `TryFromIntError` by transmuting a zero-sized `()` into it. That worked only while `TryFromIntError` was itself zero-sized. rustc 1.97 gave it a payload, so the transmute became a size mismatch and a hard error.

Nothing in this repo changed. `release.yml` uses an unpinned `setup-rust-toolchain`, so the runners rolled onto 1.97.1 and the build broke underneath us. `ethnum` is transitive: `jsonb` ← `lance-arrow` ← `lance`.

## Fix

`ethnum` 1.5.3 replaces the transmute with `u8::try_from(-1i8).unwrap_err()`. Patch-level bump, so this is a lockfile-only change — no manifest edit, no unrelated dependency churn.

## Verification

Tested against rustc 1.97.1 locally, since nothing older reproduces it:

| Check | Result |
|---|---|
| ethnum 1.5.2 on 1.96.1 | builds — confirms 1.97 is the trigger |
| ethnum 1.5.2 on 1.97.1 | **E0512**, same error as CI |
| ethnum 1.5.3 on 1.97.1 | builds |
| `cargo build --release --lib` on 1.97.1 | **exit 0** |
| ethnum 1.5.3 on 1.91.0 | builds — pinned MSRV job stays green |

The full release build matters here: CI aborted *at* ethnum, so nothing past it had ever been compiled. Running it to completion confirms ethnum was the only blocker rather than the first of several.

`cargo test` was not run locally — it hit a full disk on my machine, unrelated to this change. Relying on CI for it.

## Worth considering separately

This will recur. `release.yml` builds shipped artifacts on floating `stable`, so any future rustc release can break a tagged release at the worst possible moment — which is how v0.1.3 failed. `ci.yml` already pins `1.91.0` for the MSRV job; pinning the release toolchain (or adding a `rust-toolchain.toml`) would make release builds reproducible. Left out of this PR to keep it to the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)