### PR TITLE
ci(release): add Debian 12 build rows for a glibc 2.36 floor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,13 @@ env:
 
 jobs:
   build:
-    name: Build (${{ matrix.target }})
+    name: Build (${{ matrix.target }}${{ matrix.artifact_suffix }})
     runs-on: ${{ matrix.runner }}
+    container:
+      # An expression evaluating to empty means "no container" — the job runs
+      # directly on the runner. A literal `image: ''` fails schema validation,
+      # but an expression does not, which is what makes this pattern work.
+      image: ${{ matrix.container }}
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -27,28 +32,73 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-24.04
             os_label: linux
+            container: ""
+            artifact_suffix: ""
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
             os_label: linux
+            container: ""
+            artifact_suffix: ""
+          # Debian 12 (bookworm) ships glibc 2.36. Building inside the image
+          # pins the ABI floor by construction, independent of whatever glibc
+          # the host runner image happens to carry, so these archives keep
+          # working on bookworm-based deployments.
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+            os_label: linux
+            container: "debian:12"
+            artifact_suffix: "-debian12"
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            os_label: linux
+            container: "debian:12"
+            artifact_suffix: "-debian12"
           # x86_64-apple-darwin temporarily disabled: GitHub is deprecating
           # macos-13 runners and jobs queue 24h+ before timing out. Restore
           # this row once a macos-* Intel runner is reliably available again.
           - target: aarch64-apple-darwin
             runner: macos-14
             os_label: macos
+            container: ""
+            artifact_suffix: ""
     env:
       CC: clang
       CXX: clang++
     steps:
+      # Runs before checkout so git is present for the clone and for the
+      # Corrosion FetchContent. The image has no sudo and runs as root.
+      # xz-utils backs `tar -cJf` and perl provides `shasum`; neither is in
+      # the base image.
+      - name: Install build dependencies (container)
+        if: matrix.container != ''
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            clang \
+            cmake \
+            curl \
+            git \
+            libssl-dev \
+            perl \
+            pkg-config \
+            protobuf-compiler \
+            xz-utils
       - uses: actions/checkout@v4
+      - name: Mark workspace safe for git (container)
+        if: matrix.container != ''
+        run: git config --global --add safe.directory '*'
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}
+          # Suffix keeps the container and host builds of the same triple from
+          # sharing a cache — they link against different glibc versions.
+          key: ${{ matrix.target }}${{ matrix.artifact_suffix }}
       - name: Install protobuf (Linux)
-        if: matrix.os_label == 'linux'
+        if: matrix.os_label == 'linux' && matrix.container == ''
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Install protobuf (macOS)
         if: matrix.os_label == 'macos'
@@ -72,7 +122,8 @@ jobs:
         run: |
           VERSION=${{ steps.ver.outputs.version }}
           TARGET=${{ matrix.target }}
-          ARCHIVE="lance-c-v${VERSION}-${TARGET}.tar.xz"
+          SUFFIX=${{ matrix.artifact_suffix }}
+          ARCHIVE="lance-c-v${VERSION}-${TARGET}${SUFFIX}.tar.xz"
           tar -C stage -cJf "${ARCHIVE}" .
           shasum -a 256 "${ARCHIVE}" > "${ARCHIVE}.sha256"
           shasum -a 512 "${ARCHIVE}" > "${ARCHIVE}.sha512"
@@ -80,7 +131,7 @@ jobs:
       - name: Upload as workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.target }}
+          name: ${{ matrix.target }}${{ matrix.artifact_suffix }}
           path: |
             ${{ steps.pack.outputs.archive }}
             ${{ steps.pack.outputs.archive }}.sha256


### PR DESCRIPTION
## Problem

The Linux release archives are built on `ubuntu-24.04`, which carries **glibc 2.39**. They therefore fail to load on Debian 12 (bookworm) deployments, whose glibc is **2.36**.

## Approach

Add a `container` dimension to the build matrix, with two new Linux rows that build inside `debian:12` on the same hosts. Because the image *is* glibc 2.36, the ABI floor is pinned by construction rather than inferred from whatever glibc the runner image happens to ship — so it stays put across GitHub runner image migrations. (Worth noting: `ubuntu-22.04`, the obvious alternative, [begins deprecation 2026-09-17 and is fully unsupported 2027-04-17](https://github.com/actions/runner-images/issues/14254).) The aarch64 row runs natively on the arm host, no emulation.

The existing `ubuntu-24.04` rows are kept for now so archives already referenced by URL keep resolving. The new ones carry a `-debian12` suffix, and consumers can migrate at their own pace.

| target | runner | container | archive |
|---|---|---|---|
| x86_64-linux-gnu | ubuntu-24.04 | — | `…-x86_64-unknown-linux-gnu.tar.xz` |
| aarch64-linux-gnu | ubuntu-24.04-arm | — | `…-aarch64-unknown-linux-gnu.tar.xz` |
| x86_64-linux-gnu | ubuntu-24.04 | `debian:12` | `…-x86_64-unknown-linux-gnu-debian12.tar.xz` |
| aarch64-linux-gnu | ubuntu-24.04-arm | `debian:12` | `…-aarch64-unknown-linux-gnu-debian12.tar.xz` |
| aarch64-apple-darwin | macos-14 | — | unchanged |

### Supporting changes

- The `sudo apt-get` step is gated on the non-container rows — the image runs as root and has no `sudo`.
- The container dependency install runs **before** checkout so `git` is available for the clone and for Corrosion's `FetchContent`. It pulls in `xz-utils` and `perl`, which back `tar -cJf` and `shasum` respectively and are absent from the base image.
- The rust-cache key is suffixed so the two builds of a given triple don't share a cache across different glibc versions.
- `upload-artifact` names are suffixed to avoid a collision between the two rows sharing a target triple.

The publish job needs no change: it derives the recipe variable name from the archive filename, so it emits `LANCE_C_SHA512_<triple>-debian12` on its own.

## Test plan

Verified on a real `debian:12` container:

```
glibc:  2.36
cmake:  cmake version 3.25.1   (need >= 3.22)
protoc: libprotoc 3.21.12
clang:  Debian clang version 14.0.6
shasum   /usr/bin/shasum
xz       /usr/bin/xz
tar      /usr/bin/tar
git      /usr/bin/git
curl     /usr/bin/curl
```

The apt list resolves clean, and `actionlint` (with shellcheck) reports no new findings — the two SC2035/SC2129 hits in the publish job predate this change and were confirmed against `git show HEAD`.

**Not verified locally:** a full cargo build inside the container, since compiling lance + datafusion + arrow is a 30–60 min job. The environment is validated, the build is not. Suggest dispatching a throwaway version via `workflow_dispatch` before cutting a real tag; if anything fails, the likely cause is a transitive dep needing a system library beyond `build-essential`/`libssl-dev`/`pkg-config`.

## Follow-up worth considering

An ABI guard step (`readelf`/`nm` over the staged libraries, failing if any referenced `GLIBC_*` version exceeds 2.36) was prototyped and deliberately left out of this PR to keep it focused. Without it, a regression above the floor surfaces at a consumer's runtime rather than in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)