### PR TITLE
fix(ci): install libprotobuf-dev in the Debian 12 release containers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,11 @@ jobs:
       # Runs before checkout so git is present for the clone and for the
       # Corrosion FetchContent. The image has no sudo and runs as root.
       # xz-utils backs `tar -cJf` and perl provides `shasum`; neither is in
-      # the base image.
+      # the base image. libprotobuf-dev supplies the well-known .proto files
+      # under /usr/include/google/protobuf/, which lance-encoding's build
+      # script imports; protobuf-compiler only Recommends it, so
+      # --no-install-recommends drops it and protoc fails to resolve
+      # google/protobuf/empty.proto.
       - name: Install build dependencies (container)
         if: matrix.container != ''
         run: |
@@ -80,6 +84,7 @@ jobs:
             cmake \
             curl \
             git \
+            libprotobuf-dev \
             libssl-dev \
             perl \
             pkg-config \


### PR DESCRIPTION
Fixes the two failing `debian12` rows in the [v0.1.5 release run](https://github.com/lance-format/lance-c/actions/runs/31073039760). Regression from #53, which was mine.

## What broke

Both `debian12` rows died at `Configure + build` about 14 minutes in, while the `ubuntu-24.04` rows succeeded:

```
error: failed to run custom build command for `lance-encoding v7.0.0-beta.7`
Caused by:
  Error: Custom { kind: Other, error: "protoc failed: google/protobuf/empty.proto: File not found.
  encodings_v2_0.proto:8:1: Import \"google/protobuf/empty.proto\" was not found or had errors.
  encodings_v2_0.proto:343:5: \"google.protobuf.Empty\" is not defined." }
```

`protoc` installed fine. What was missing were the well-known type definitions under `/usr/include/google/protobuf/`, which `lance-encoding`'s build script imports.

## Root cause

On Debian and Ubuntu those `.proto` files ship in `libprotobuf-dev`, and `protobuf-compiler` only *Recommends* it rather than depending on it. The `ubuntu-24.04` rows run a plain `apt-get install -y protobuf-compiler`, which honors Recommends and picks it up implicitly. The container step I added in #53 uses `--no-install-recommends`, which silently dropped it.

Isolated by comparing all four combinations in real containers:

| environment | `empty.proto` | import compiles |
|---|---|---|
| debian:12, `protobuf-compiler --no-install-recommends` | missing | **FAILS** |
| debian:12, `protobuf-compiler` (recommends on) | present | OK |
| debian:12, `protobuf-compiler libprotobuf-dev` | present | OK |
| ubuntu:24.04, `protobuf-compiler` | present | OK |

Row 1 reproduces the CI failure with the same two error strings. Rows 2 and 3 both resolve it.

## Why this fix

Adding `libprotobuf-dev` explicitly rather than dropping `--no-install-recommends`. It names the actual dependency, and it keeps the other eleven packages from pulling in their own recommends.

## Test plan

The controlled comparison above was run in real `debian:12` and `ubuntu:24.04` containers. `actionlint` reports no new findings (the two SC2035/SC2129 hits in the publish job predate #53).

Full end-to-end proof is the release workflow itself. Worth re-dispatching `Release` at `v0.1.5` once this lands, before cutting anything new.

## Note for #50

If #50 lands, this becomes moot for the same reason: its protoc install extracts `include/*` from the upstream release zip, which is exactly the well-known types. That approach sidesteps the Recommends trap entirely and is arguably the more robust one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)