### PR TITLE
chore(deps): bump lance to 9.1.0-beta.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,6 +3703,7 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
+ "chrono",
  "datafusion",
  "futures",
  "half",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,21 +43,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,7 +289,7 @@ dependencies = [
  "arrow-select",
  "chrono",
  "half",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "lexical-core",
  "memchr",
@@ -650,7 +635,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.9",
  "time",
  "tracing",
 ]
@@ -880,15 +865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "bitpacking"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,7 +882,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -933,33 +909,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "brotli"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -993,6 +957,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "byteorder"
@@ -1096,7 +1074,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1215,6 +1193,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1398,6 +1382,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1419,16 @@ checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
+]
+
+[[package]]
+name = "ctor"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
 ]
 
 [[package]]
@@ -1484,14 +1487,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
+checksum = "754ef4e8f073922a26f5b23133b9db4829342362b09be0bc94309cf261c2f098"
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
- "bytes",
  "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
@@ -1501,7 +1503,6 @@ dependencies = [
  "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
- "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -1519,13 +1520,11 @@ dependencies = [
  "datafusion-session",
  "datafusion-sql",
  "futures",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
- "parquet",
- "rand 0.9.2",
- "regex",
  "sqlparser",
  "tempfile",
  "tokio",
@@ -1535,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
+checksum = "06afd1e38dd27bbb1258685a1fc6524df6aff4e07b25b393a47de59635178d99"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1560,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
+checksum = "f0668fb32c12065ec242be0e5b4bc62bd7a06a0be3ecd83791ef877e4be67e02"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1583,33 +1582,33 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
+checksum = "ca43b263cdff57042cfa8fb817fb3469f4878933380dccff25f5e793580abbf9"
 dependencies = [
- "ahash",
  "arrow",
  "arrow-ipc",
+ "arrow-schema",
  "chrono",
+ "foldhash 0.2.0",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "libc",
  "log",
  "object_store",
- "parquet",
- "paste",
  "sqlparser",
  "tokio",
+ "uuid",
  "web-time",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
+checksum = "05f0ba2b864792bdca4d76c59a1de0ab6e1b61946596b9936888dbd6360035f2"
 dependencies = [
  "futures",
  "log",
@@ -1618,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
+checksum = "b840a8bce0bcbf5afad02946d438591e7c373f7afccaf3d874c04485772514dd"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1640,6 +1639,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
+ "parking_lot",
  "rand 0.9.2",
  "tokio",
  "url",
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
+checksum = "a24cc0b9cf6e367f27f27406eff13abf48a11b72446aaa40b3105c0ded5c17d9"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1671,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
+checksum = "e1abe56b2a7a2d1d6de5117dd1a203181e267f28529faa5da546947621b697d7"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1694,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
+checksum = "9c3e467f0611ad7bdd5aad17c63c9bb6182d04e5282e5496d897ea2b49c024ba"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1711,57 +1711,25 @@ dependencies = [
  "datafusion-session",
  "futures",
  "object_store",
- "serde_json",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
-name = "datafusion-datasource-parquet"
-version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
-dependencies = [
- "arrow",
- "async-trait",
- "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions-aggregate-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-pruning",
- "datafusion-session",
- "futures",
- "itertools 0.14.0",
- "log",
- "object_store",
- "parking_lot",
- "parquet",
- "tokio",
-]
-
-[[package]]
 name = "datafusion-doc"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
+checksum = "d69bb69d8769e34f76839c960dbde24c1ac0c885a79b6c3c2287bdc56ec67891"
 
 [[package]]
 name = "datafusion-execution"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
+checksum = "d8eac0a09bc8d263f52025cad9e001da4d8138d633fa288edda4d06b1772eae6"
 dependencies = [
  "arrow",
  "arrow-buffer",
  "async-trait",
- "chrono",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -1777,11 +1745,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
+checksum = "eeb14d374767ee0fc62dc79a5ba8bcf8a63c14e993c7d992d0e63adfa23d77d3"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1790,31 +1759,29 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
- "paste",
  "serde_json",
  "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-expr-common"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
+checksum = "b7b19a8c95522bee8cbb313d74263b85e355d2b52f42e67ef5694bf5de9e9356"
 dependencies = [
  "arrow",
  "datafusion-common",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
+checksum = "5f64c983bbbdcb729d921a2b2ac3375598719b5cc0c30345ad664936f3176fc7"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1829,26 +1796,25 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-macros",
+ "datafusion-physical-expr-common",
  "hex",
  "itertools 0.14.0",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
  "num-traits",
  "rand 0.9.2",
  "regex",
- "sha2",
- "unicode-segmentation",
+ "sha2 0.11.0",
  "uuid",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
+checksum = "89bc17041e424a47ed062f43df24d84aab8b57c4c3221e5c1a5eef46d6c5718b"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -1858,19 +1824,18 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "foldhash 0.2.0",
  "half",
  "log",
  "num-traits",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
+checksum = "97dd2a9e865c6108059f5b37b77934f84b50bfb108f837bd0e5c9536e03f0545"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -1879,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
+checksum = "75f0bdfeef16d96417b9632ef855645376b242e9006a126dfd0bedfc54a93f5f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1895,34 +1860,34 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itertools 0.14.0",
  "itoa",
  "log",
- "paste",
+ "memchr",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
+checksum = "f4e4941673c917819616877e9993da4503e4f4739812be0bc32c5356184c6383"
 dependencies = [
  "arrow",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr",
  "datafusion-physical-plan",
  "parking_lot",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
+checksum = "12dd2e16c12b84b6f6b41b19f55b366dd1c46876bb35b86896c6349067379e8d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1933,14 +1898,13 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
+checksum = "4cdc5e4b6f8b6ef823cc1c761f85088ad4c884fe8df64df3cbcc6b2b84698441"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1948,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
+checksum = "1a3614234dd93578c92428cb4f408e020874f0d2b7e6c90c928d9d28b5df2ceb"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -1959,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
+checksum = "a0635620b050b81bb92764e99250868f654e2cd5ad1bece413283b3f73c83179"
 dependencies = [
  "arrow",
  "chrono",
@@ -1969,7 +1933,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "regex",
@@ -1978,11 +1942,10 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
+checksum = "8cabf7a86eb70b816729e33c81bf7767c936ee1226f607a114f5dac2decac8d0"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -1990,20 +1953,19 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
- "paste",
  "petgraph",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
+checksum = "de222e04f7e6744501555a54ab0abe26bfdfebee380af79a9bdc175704246859"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2016,26 +1978,26 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
+checksum = "72d0d0057fc5a502d45c870cb6d47c66eb7bdd5edb1bd71ad6f3f724975ac2a8"
 dependencies = [
- "ahash",
  "arrow",
  "chrono",
  "datafusion-common",
  "datafusion-expr-common",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
+ "pin-project",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
+checksum = "86046eed10950c5f9aaed9acfd148e9bd2e1dfdfe4f9aef607d1447b271e4183"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2051,12 +2013,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
+checksum = "9bc84da934c903407ba297971ebcc020c4c1a38aafd765d6c144c76eff3fa6a1"
 dependencies = [
- "ahash",
  "arrow",
+ "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "async-trait",
@@ -2071,8 +2034,8 @@ dependencies = [
  "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "num-traits",
@@ -2083,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
+checksum = "eb63eeac6de19be40f487b65dd84e546195f783c5a9928618e0c4f2a3569b0d7"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2094,15 +2057,14 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools 0.14.0",
  "log",
 ]
 
 [[package]]
 name = "datafusion-session"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
+checksum = "5f961d209177f91bd014db5cbb2c33b7d28a2597b9003e77f17aeb712964315a"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2114,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
+checksum = "b1d71cb454da682b2af7488e1fc1ddd72ee1b28f19297b8ccad73f0a21ee9a69"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2124,7 +2086,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions-nested",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "regex",
  "sqlparser",
@@ -2132,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-substrait"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98494539a5468979cc42d86c7bc5f0f8cb71ee5c742694c26fc34efdd29dd2e5"
+checksum = "f047a6fbf967b6b523758a48d2377bb5f9373a20e7ae4c4326d3c569f80ba3d7"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2151,32 +2113,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "deepsize"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
-dependencies = [
- "deepsize_derive",
-]
-
-[[package]]
-name = "deepsize_derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -2197,10 +2139,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -2381,7 +2334,6 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs",
 ]
 
 [[package]]
@@ -2425,8 +2377,8 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrow-array",
  "rand 0.9.2",
@@ -2654,12 +2606,13 @@ dependencies = [
 
 [[package]]
 name = "geodatafusion"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cd430f1a1f59bc97053d824ad410ea6fd123c8977b3c1a75335e289233b8b"
+checksum = "fecbdd00d0fff2b04635c1b1e4129c217908f0c2d17539e0a2275308afce2552"
 dependencies = [
  "arrow-arith",
  "arrow-array",
+ "arrow-buffer",
  "arrow-schema",
  "datafusion",
  "geo",
@@ -2773,6 +2726,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "goosefs-sdk"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae079b88ffe7772d12cfc5c40a5a324babb357893d95b5e3a22ae857f236c5f"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "dashmap",
+ "hostname",
+ "prost",
+ "prost-types",
+ "rand 0.9.2",
+ "reqwest 0.12.28",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,7 +2761,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2797,6 +2774,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
@@ -2851,6 +2829,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapify"
@@ -2914,7 +2897,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -2979,10 +2973,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2998,6 +3007,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -3020,6 +3030,20 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -3126,35 +3150,58 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locale_core"
-version = "2.1.1"
+name = "icu_locale"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_normalizer"
-version = "2.1.1"
+name = "icu_locale_data"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -3166,15 +3213,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -3186,24 +3233,47 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -3251,12 +3321,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3270,12 +3340,6 @@ dependencies = [
  "block-padding",
  "generic-array",
 ]
-
-[[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-uring"
@@ -3315,15 +3379,6 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3468,7 +3523,7 @@ dependencies = [
  "jiff",
  "nom",
  "num-traits",
- "ordered-float 5.1.0",
+ "ordered-float",
  "rand 0.9.2",
  "ryu",
  "serde",
@@ -3512,9 +3567,10 @@ checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "lance"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
+ "arc-swap",
  "arrow",
  "arrow-arith",
  "arrow-array",
@@ -3532,6 +3588,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "crossbeam-queue",
  "crossbeam-skiplist",
  "dashmap",
  "datafusion",
@@ -3539,22 +3596,23 @@ dependencies = [
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-physical-plan",
- "deepsize",
  "either",
+ "fst",
  "futures",
  "half",
  "humantime",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lance-arrow",
+ "lance-bitpacking",
  "lance-core",
  "lance-datafusion",
  "lance-encoding",
  "lance-file",
- "lance-geo",
  "lance-index",
  "lance-io",
  "lance-linalg",
  "lance-namespace",
+ "lance-select",
  "lance-table",
  "lance-tokenizer",
  "log",
@@ -3566,7 +3624,9 @@ dependencies = [
  "prost-build",
  "prost-types",
  "rand 0.9.2",
+ "rayon",
  "roaring",
+ "rustc-hash",
  "semver",
  "serde",
  "serde_json",
@@ -3581,17 +3641,17 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-data",
  "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
+ "bytemuck",
  "bytes",
  "futures",
  "getrandom 0.2.17",
@@ -3602,11 +3662,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-arrow-scalar"
+version = "58.0.0"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-row",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "lance-arrow-stats"
+version = "58.0.0"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "lance-arrow-scalar",
+]
+
+[[package]]
 name = "lance-bitpacking"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrayref",
+ "crunchy",
  "paste",
  "seq-macro",
 ]
@@ -3640,25 +3725,25 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
+ "arrow-data",
  "arrow-schema",
  "async-trait",
  "byteorder",
  "bytes",
- "chrono",
  "datafusion-common",
  "datafusion-sql",
- "deepsize",
  "futures",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lance-arrow",
+ "lance-derive",
  "libc",
+ "libm",
  "log",
- "mock_instant",
  "moka",
  "num_cpus",
  "object_store",
@@ -3673,13 +3758,14 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "twox-hash",
  "url",
 ]
 
 [[package]]
 name = "lance-datafusion"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3705,16 +3791,14 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-build",
- "snafu",
- "substrait",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "lance-datagen"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3727,13 +3811,22 @@ dependencies = [
  "rand 0.9.2",
  "rand_distr",
  "rand_xoshiro",
- "random_word",
+]
+
+[[package]]
+name = "lance-derive"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "lance-encoding"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3749,7 +3842,7 @@ dependencies = [
  "futures",
  "hex",
  "hyperloglogplus",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lance-arrow",
  "lance-bitpacking",
  "lance-core",
@@ -3758,9 +3851,7 @@ dependencies = [
  "num-traits",
  "prost",
  "prost-build",
- "prost-types",
  "rand 0.9.2",
- "snafu",
  "strum",
  "tokio",
  "tracing",
@@ -3770,8 +3861,8 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3784,7 +3875,6 @@ dependencies = [
  "byteorder",
  "bytes",
  "datafusion-common",
- "deepsize",
  "futures",
  "lance-arrow",
  "lance-core",
@@ -3796,15 +3886,14 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "snafu",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "lance-geo"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "datafusion",
  "geo-traits",
@@ -3818,8 +3907,8 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -3831,7 +3920,6 @@ dependencies = [
  "async-channel",
  "async-recursion",
  "async-trait",
- "bitpacking",
  "bitvec",
  "bytes",
  "chrono",
@@ -3840,8 +3928,6 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
- "datafusion-sql",
- "deepsize",
  "dirs",
  "fst",
  "futures",
@@ -3849,20 +3935,24 @@ dependencies = [
  "geoarrow-array",
  "geoarrow-schema",
  "half",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "jsonb",
  "lance-arrow",
+ "lance-arrow-stats",
+ "lance-bitpacking",
  "lance-core",
  "lance-datafusion",
  "lance-datagen",
  "lance-encoding",
  "lance-file",
  "lance-geo",
+ "lance-index-core",
  "lance-io",
  "lance-linalg",
+ "lance-select",
  "lance-table",
  "lance-tokenizer",
- "libm",
+ "libsais-rs",
  "log",
  "ndarray",
  "num-traits",
@@ -3874,22 +3964,44 @@ dependencies = [
  "rand_distr",
  "rangemap",
  "rayon",
+ "regex-syntax",
  "roaring",
  "serde",
  "serde_json",
  "smallvec",
- "snafu",
  "tempfile",
  "tokio",
  "tracing",
- "twox-hash",
  "uuid",
 ]
 
 [[package]]
+name = "lance-index-core"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "arrow-select",
+ "async-trait",
+ "bytes",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "futures",
+ "lance-core",
+ "lance-io",
+ "lance-select",
+ "prost-types",
+ "roaring",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lance-io"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3906,14 +4018,13 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "deepsize",
  "futures",
+ "goosefs-sdk",
  "http 1.4.0",
  "io-uring",
  "lance-arrow",
  "lance-core",
  "lance-namespace",
- "libc",
  "log",
  "moka",
  "object_store",
@@ -3924,7 +4035,6 @@ dependencies = [
  "prost",
  "rand 0.9.2",
  "serde",
- "snafu",
  "tempfile",
  "tokio",
  "tracing",
@@ -3933,40 +4043,39 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-schema",
  "cc",
- "deepsize",
  "half",
  "lance-arrow",
  "lance-core",
  "num-traits",
  "rand 0.9.2",
+ "rayon",
 ]
 
 [[package]]
 name = "lance-namespace"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrow",
  "async-trait",
  "bytes",
  "lance-core",
  "lance-namespace-reqwest-client",
- "serde",
  "snafu",
 ]
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.7.6"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65e31bdaa13e01dab6e7cf566da31df243c34a542f0d915d3601ec0e01e61d2"
+checksum = "ba3f0a235e3ed5f8805205649ccc7d7d0f3df23ce1294242c9265ad488d7f19d"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -3977,9 +4086,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-select"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "byteorder",
+ "bytes",
+ "itertools 0.14.0",
+ "lance-core",
+ "roaring",
+ "tracing",
+]
+
+[[package]]
 name = "lance-table"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3990,12 +4115,12 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "deepsize",
  "futures",
  "lance-arrow",
  "lance-core",
  "lance-file",
  "lance-io",
+ "lance-select",
  "log",
  "object_store",
  "prost",
@@ -4016,11 +4141,13 @@ dependencies = [
 
 [[package]]
 name = "lance-tokenizer"
-version = "7.0.0-beta.7"
-source = "git+https://github.com/lance-format/lance.git?rev=e0e977a6#f6932459689b5568c89baa435ff85a4abf067b45"
+version = "9.1.0-beta.3"
+source = "git+https://github.com/lance-format/lance.git?rev=e934cc2c#e934cc2ceda2bd5f5aa37a953cc29f71d24bd5c0"
 dependencies = [
+ "icu_segmenter",
  "rust-stemmers",
  "serde",
+ "stop-words",
  "unicode-normalization",
 ]
 
@@ -4098,9 +4225,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -4116,6 +4243,27 @@ checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "libsais-rs"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00777f770949ecbe5524eb6630699a501c9c27e4d18493705a7dad49c9bdfbd1"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "link-section"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4220,7 +4368,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if 1.0.4",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if 1.0.4",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4266,20 +4424,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "mock_instant"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "moka"
@@ -4506,10 +4658,10 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools 0.14.0",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.39.4",
+ "quick-xml",
  "rand 0.10.1",
  "reqwest 0.12.28",
  "ring",
@@ -4528,9 +4680,9 @@ dependencies = [
 
 [[package]]
 name = "object_store_opendal"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08298874eee5935c95bcaa393148834f9c53d904461ca15584a041d8a1c907c2"
+checksum = "0eb12a624a41fce745838d0ef3701ff6c47797c13cd18ad3612fd2a3134fdbd8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4563,11 +4715,11 @@ checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "opendal"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
+checksum = "96c9c85ce253ff87225e7669979d877a20c98a06604ec9d6dd5f4473e08f1ae1"
 dependencies = [
- "ctor",
+ "ctor 1.0.13",
  "opendal-core",
  "opendal-layer-concurrent-limit",
  "opendal-layer-logging",
@@ -4577,16 +4729,18 @@ dependencies = [
  "opendal-service-azdls",
  "opendal-service-cos",
  "opendal-service-gcs",
+ "opendal-service-goosefs",
  "opendal-service-hf",
  "opendal-service-oss",
  "opendal-service-s3",
+ "opendal-service-tos",
 ]
 
 [[package]]
 name = "opendal-core"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849dd2687e173e776d3af5fce1ba3ae47b9dd37a09d1c4deba850ef45fe00ca"
+checksum = "c4f8607c90e2c963a91467f50fb49fbc7fb3d573f88cea219ca59ccd3740b309"
 dependencies = [
  "anyhow",
  "base64",
@@ -4596,10 +4750,10 @@ dependencies = [
  "http-body 1.0.1",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "mea",
  "percent-encoding",
- "quick-xml 0.38.4",
+ "quick-xml",
  "reqsign-core",
  "reqwest 0.13.3",
  "serde",
@@ -4612,9 +4766,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-concurrent-limit"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048b1b29c503263bdd80a9afe46a68cd02ea9bd361185b1feab4b151078998e9"
+checksum = "0d6f81ba6960e3fae1882f253b114b21d7e444e1534f209c7737a79f6243eb6f"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4624,9 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2645adc988b12eda106e2679ae529facfbbaa868ceb706f6f8125c6af15c47b"
+checksum = "58ada45c6d81d1aa4c9305d0c7d4bc317c59c85866a0908a2d75a7a978aa5ee2"
 dependencies = [
  "log",
  "opendal-core",
@@ -4634,9 +4788,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eac134ffa4ddda6131a640a84a5315996424b9416c85052f8c64c1a33b70ad4"
+checksum = "7b2a25a718afb81fad81cb9a0580a1cb989221fa2317f888c6a37f8dad408eb7"
 dependencies = [
  "backon",
  "log",
@@ -4645,9 +4799,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619586ab7480c2e3009f6d18eabab18957bc094778fd130bcc38924970a90f4c"
+checksum = "1e91f731724c213af81e9d03517859c8fc47b4578e64ad61ae4f099f10fe36e3"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -4655,9 +4809,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azblob"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7452bf3ec61cfd81ac9ad9ada17825931e9e371d44a045c6bfab9596c0a2ac3b"
+checksum = "0030644366ef5d8cbe3a4a5822bf99a4aafddc1666e9d24b44d158d9062fc76a"
 dependencies = [
  "base64",
  "bytes",
@@ -4665,27 +4819,28 @@ dependencies = [
  "log",
  "opendal-core",
  "opendal-service-azure-common",
- "quick-xml 0.38.4",
+ "quick-xml",
  "reqsign-azure-storage",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "serde",
- "sha2",
+ "sha2 0.11.0",
  "uuid",
 ]
 
 [[package]]
 name = "opendal-service-azdls"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9884c2d8cf8ba2bb077d79c877dac5863ba3bab9e2c9c1e41a2e0491404772"
+checksum = "6dea4908d490143a9b0b7f7a790e139ff829b06a023f670455ed3d44f664b361"
 dependencies = [
+ "base64",
  "bytes",
  "http 1.4.0",
  "log",
  "opendal-core",
  "opendal-service-azure-common",
- "quick-xml 0.38.4",
+ "quick-xml",
  "reqsign-azure-storage",
  "reqsign-core",
  "reqsign-file-read-tokio",
@@ -4695,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb0e45d6c8dcf66ce2da20e241bcb80e6e540e109a4ff20f318f6c9b4c54e0c"
+checksum = "9b489f13c42e69d69bdd72952b634356ec43a7881a20259b38b540fcecdf4051"
 dependencies = [
  "http 1.4.0",
  "opendal-core",
@@ -4705,15 +4860,15 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cos"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a0765ba451b6effdbf514b7b50060530ff8a29e4231c4a3ab7792c016408e6"
+checksum = "aa8cafe9729213375c7331019b0cb756ad3e1aff7f45cd32c45eae91ebde8901"
 dependencies = [
  "bytes",
  "http 1.4.0",
  "log",
  "opendal-core",
- "quick-xml 0.38.4",
+ "quick-xml",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "reqsign-tencent-cos",
@@ -4722,9 +4877,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a49477a10163431896d106136117f5670717f9c9e49cf6f710528800c6633a"
+checksum = "48de101aac565ed06af4b47903c24eafd249075553ec1fb18256751c45148d47"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4732,7 +4887,7 @@ dependencies = [
  "log",
  "opendal-core",
  "percent-encoding",
- "quick-xml 0.38.4",
+ "quick-xml",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "reqsign-google",
@@ -4742,10 +4897,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "opendal-service-hf"
-version = "0.56.0"
+name = "opendal-service-goosefs"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2ab7a2a8a11dfe257ef4db5c0de798acbcd0d6429c37382dad2154bc06a388"
+checksum = "69e43048bde419947ba826fbdc2f134d6c03f44ebf48bd33a03b72f9fc45fcb4"
+dependencies = [
+ "bytes",
+ "goosefs-sdk",
+ "log",
+ "opendal-core",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "opendal-service-hf"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4922661976a1d40794a2adfbdb888cc3c23097690f825a92f773af38908a848"
 dependencies = [
  "bytes",
  "hf-xet",
@@ -4760,15 +4929,15 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-oss"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c8a917829ad06d21b639558532cb0101fe49b040d946d673a73018683fac05"
+checksum = "328fa55e8888cbdfe00826bfea2a79042422b720e8369e9e021e46121dea5ace"
 dependencies = [
  "bytes",
  "http 1.4.0",
  "log",
  "opendal-core",
- "quick-xml 0.38.4",
+ "quick-xml",
  "reqsign-aliyun-oss",
  "reqsign-core",
  "reqsign-file-read-tokio",
@@ -4777,23 +4946,40 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dadddeb9bb50b0d30927dd914c298c4ddca47e4c1cfa7674d311f0cf9b051c8"
+checksum = "313d46c9f5ae70bca26b7c3e3fbb9b639292625f28af73aa016f47e788af9deb"
 dependencies = [
  "base64",
  "bytes",
  "crc32c",
  "http 1.4.0",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "opendal-core",
- "quick-xml 0.38.4",
+ "quick-xml",
  "reqsign-aws-v4",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "serde",
  "url",
+]
+
+[[package]]
+name = "opendal-service-tos"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f2f7a4c32e5202eb4ac72e76c4b5e30c86ab60762811172f4111103b9d673a1"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+ "opendal-core",
+ "quick-xml",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "reqsign-volcengine-tos",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4807,15 +4993,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "ordered-float"
@@ -4881,42 +5058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parquet"
-version = "58.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
- "base64",
- "brotli",
- "bytes",
- "chrono",
- "flate2",
- "futures",
- "half",
- "hashbrown 0.17.1",
- "lz4_flex",
- "num-bigint",
- "num-integer",
- "num-traits",
- "object_store",
- "paste",
- "seq-macro",
- "simdutf8",
- "snap",
- "thrift",
- "tokio",
- "twox-hash",
- "zstd",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4977,7 +5118,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -5020,7 +5161,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -5096,7 +5237,7 @@ dependencies = [
  "der",
  "pbkdf2",
  "scrypt",
- "sha2",
+ "sha2 0.10.9",
  "spki",
 ]
 
@@ -5139,6 +5280,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -5234,16 +5377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -5434,19 +5567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "random_word"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47a395bdb55442b883c89062d6bcff25dc90fa5f8369af81e0ac6d49d78cf81"
-dependencies = [
- "ahash",
- "brotli",
- "paste",
- "rand 0.9.2",
- "unicase",
-]
-
-[[package]]
 name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5601,7 +5721,7 @@ dependencies = [
  "http 1.4.0",
  "log",
  "percent-encoding",
- "quick-xml 0.39.4",
+ "quick-xml",
  "reqsign-core",
  "rust-ini",
  "serde",
@@ -5650,7 +5770,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "windows-sys 0.61.2",
 ]
 
@@ -5681,7 +5801,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
 ]
 
@@ -5698,6 +5818,19 @@ dependencies = [
  "reqsign-core",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "reqsign-volcengine-tos"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d757602a7ef2b6025c0da77e6d2e23fbdef35930fa466b15ffbf0a3f13acf7"
+dependencies = [
+ "anyhow",
+ "http 1.4.0",
+ "log",
+ "percent-encoding",
+ "reqsign-core",
 ]
 
 [[package]]
@@ -5743,6 +5876,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5835,15 +5969,15 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -6098,7 +6232,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6187,6 +6321,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -6240,7 +6375,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -6267,7 +6402,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -6282,7 +6417,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6293,8 +6428,19 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
  "sha2-asm",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6348,7 +6494,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6426,12 +6572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
-
-[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6471,9 +6611,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -6525,6 +6665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
 
 [[package]]
+name = "stop-words"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68df56303396bcfb639455b3c166804aeb7994005010aab5e9e8a1277b8871d"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6554,11 +6703,12 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.62.2"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fc4b483a129b9772ccb9c3f7945a472112fdd9140da87f8a4e7f1d44e045d0"
+checksum = "e620ff4d5c02fd6f7752931aa74b16a26af66a63022cc1ad412c77edbe0bab47"
 dependencies = [
  "heck",
+ "indexmap 2.14.0",
  "pbjson",
  "pbjson-build",
  "pbjson-types",
@@ -6591,9 +6741,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6602,9 +6752,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6750,17 +6900,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float 2.10.1",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6802,11 +6941,12 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -6827,9 +6967,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -6843,13 +6983,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6913,7 +7053,7 @@ version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -6929,6 +7069,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "h2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6936,11 +7115,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7082,9 +7265,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typewit"
@@ -7234,9 +7417,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7399,7 +7582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7438,7 +7621,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -7467,6 +7650,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7829,7 +8021,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -7860,7 +8052,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -7879,7 +8071,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -8023,7 +8215,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -8049,7 +8241,7 @@ dependencies = [
  "chrono",
  "colored",
  "const-str",
- "ctor",
+ "ctor 0.6.3",
  "dirs",
  "futures",
  "git-version",
@@ -8090,9 +8282,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -8101,9 +8293,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8174,21 +8366,23 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -8196,20 +8390,14 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ rust-version = "1.91.0"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-lance = { git = "https://github.com/lance-format/lance.git", rev = "e0e977a6", features = ["substrait"] }
-lance-core = { git = "https://github.com/lance-format/lance.git", rev = "e0e977a6" }
-lance-file = { git = "https://github.com/lance-format/lance.git", rev = "e0e977a6" }
-lance-index = { git = "https://github.com/lance-format/lance.git", rev = "e0e977a6" }
-lance-io = { git = "https://github.com/lance-format/lance.git", rev = "e0e977a6" }
-lance-linalg = { git = "https://github.com/lance-format/lance.git", rev = "e0e977a6" }
+lance = { git = "https://github.com/lance-format/lance.git", rev = "e934cc2c", features = ["substrait"] }
+lance-core = { git = "https://github.com/lance-format/lance.git", rev = "e934cc2c" }
+lance-file = { git = "https://github.com/lance-format/lance.git", rev = "e934cc2c" }
+lance-index = { git = "https://github.com/lance-format/lance.git", rev = "e934cc2c" }
+lance-io = { git = "https://github.com/lance-format/lance.git", rev = "e934cc2c" }
+lance-linalg = { git = "https://github.com/lance-format/lance.git", rev = "e934cc2c" }
 arrow = { version = "58.0.0", features = ["prettyprint", "ffi"] }
 arrow-array = "58.0.0"
 arrow-schema = "58.0.0"
@@ -36,12 +36,12 @@ snafu = "0.9"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-lance = { git = "https://github.com/lance-format/lance.git", rev = "e0e977a6", features = ["substrait"] }
-lance-datafusion = { git = "https://github.com/lance-format/lance.git", rev = "e0e977a6", features = ["substrait"] }
-lance-datagen = { git = "https://github.com/lance-format/lance.git", rev = "e0e977a6" }
-lance-file = { git = "https://github.com/lance-format/lance.git", rev = "e0e977a6" }
-lance-table = { git = "https://github.com/lance-format/lance.git", rev = "e0e977a6" }
-datafusion = { version = "53.1.0", default-features = false }
+lance = { git = "https://github.com/lance-format/lance.git", rev = "e934cc2c", features = ["substrait"] }
+lance-datafusion = { git = "https://github.com/lance-format/lance.git", rev = "e934cc2c", features = ["substrait"] }
+lance-datagen = { git = "https://github.com/lance-format/lance.git", rev = "e934cc2c" }
+lance-file = { git = "https://github.com/lance-format/lance.git", rev = "e934cc2c" }
+lance-table = { git = "https://github.com/lance-format/lance.git", rev = "e934cc2c" }
+datafusion = { version = "54.0.0", default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 arrow-array = "58.0.0"
 arrow-schema = "58.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ lance-linalg = { git = "https://github.com/lance-format/lance.git", rev = "e934c
 arrow = { version = "58.0.0", features = ["prettyprint", "ffi"] }
 arrow-array = "58.0.0"
 arrow-schema = "58.0.0"
+# Direct only to name `chrono::TimeDelta`, the field type of lance's public
+# `AutoCleanupParams`; already in the graph transitively via lance.
+chrono = { version = "0.4", default-features = false }
 half = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 futures = "0.3"

--- a/include/lance/lance.h
+++ b/include/lance/lance.h
@@ -1089,6 +1089,12 @@ typedef enum {
  * Write an Arrow record batch stream to a Lance dataset at `uri`, committing
  * a manifest.
  *
+ * A dataset created through this call records an auto-cleanup policy in its
+ * manifest: every 20 committed versions, versions older than 14 days are
+ * reclaimed automatically. Callers relying on lance_dataset_versions /
+ * lance_dataset_restore for time travel should be aware that versions past
+ * that horizon may no longer exist.
+ *
  * @param uri          Dataset URI (file://, s3://, memory://, etc.). Must not
  *                     be NULL or an empty string.
  * @param schema       Required Arrow schema. The stream schema must match or

--- a/include/lance/lance.h
+++ b/include/lance/lance.h
@@ -280,9 +280,9 @@ LanceDataset* lance_dataset_restore(const LanceDataset* dataset, uint64_t versio
  *                         left unchanged — do not read it.
  * @return 0 on success, -1 on error. Error codes:
  *         LANCE_ERR_INVALID_ARGUMENT for NULL/empty args (validated at this
- *         boundary), LANCE_ERR_INTERNAL for malformed SQL or unknown columns
- *         (surfaced from the upstream parser), and LANCE_ERR_COMMIT_CONFLICT
- *         for a concurrent writer.
+ *         boundary) and for malformed SQL or unknown columns (surfaced from
+ *         the upstream parser since Lance 9.1; previously LANCE_ERR_INTERNAL),
+ *         and LANCE_ERR_COMMIT_CONFLICT for a concurrent writer.
  */
 int32_t lance_dataset_delete(
     LanceDataset* dataset,
@@ -635,12 +635,11 @@ typedef struct LanceSqlColumn {
  * @return 0 on success, -1 on error. Error codes:
  *         LANCE_ERR_INVALID_ARGUMENT for NULL/empty inputs, NULL or empty
  *         `name` / `expression`, non-UTF-8 strings, malformed SQL *syntax*, a
- *         new column name that collides with an existing column, or a
- *         `batch_size` beyond UINT32_MAX. An expression that references a
- *         *non-existent column* surfaces as LANCE_ERR_INTERNAL (an upstream
- *         schema error, the same path as lance_dataset_delete), not
- *         LANCE_ERR_INVALID_ARGUMENT. LANCE_ERR_COMMIT_CONFLICT for a
- *         concurrent writer.
+ *         new column name that collides with an existing column, an
+ *         expression that references a non-existent column (an upstream
+ *         schema error reclassified in Lance 9.1; previously
+ *         LANCE_ERR_INTERNAL), or a `batch_size` beyond UINT32_MAX.
+ *         LANCE_ERR_COMMIT_CONFLICT for a concurrent writer.
  */
 int32_t lance_dataset_add_columns_sql(
     LanceDataset* dataset,

--- a/include/lance/lance.hpp
+++ b/include/lance/lance.hpp
@@ -557,10 +557,8 @@ public:
     ///
     /// `columns` must be non-empty and each entry's `name` and `expression`
     /// must be non-empty. Throws lance::Error on failure (empty list, empty
-    /// name/expression, malformed SQL syntax, name collision with an existing
-    /// column, commit conflict, ...). A reference to a non-existent column
-    /// throws with code `LANCE_ERR_INTERNAL` (an upstream schema error), not
-    /// `LANCE_ERR_INVALID_ARGUMENT` — see the C header for the rationale.
+    /// name/expression, malformed SQL syntax, a reference to a non-existent
+    /// column, name collision with an existing column, commit conflict, ...).
     void add_columns_sql(const std::vector<SqlColumn>& columns,
                          uint64_t batch_size = 0) {
         // The C strings we install in each entry borrow from `columns` (the

--- a/src/add_columns.rs
+++ b/src/add_columns.rs
@@ -26,7 +26,6 @@ use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use arrow_schema::Schema as ArrowSchema;
 use lance::dataset::NewColumnTransform;
 use lance_core::Result;
-use snafu::location;
 
 use crate::dataset::LanceDataset;
 use crate::error::ffi_try;
@@ -86,22 +85,19 @@ unsafe fn add_columns_sql_inner(
     batch_size: u64,
 ) -> Result<i32> {
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
     if columns.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "columns must not be NULL".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "columns must not be NULL".into(),
+        ));
     }
     if num_columns == 0 {
-        return Err(lance_core::Error::InvalidInput {
-            source: "num_columns must be > 0".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "num_columns must be > 0".into(),
+        ));
     }
 
     let batch_size = resolve_batch_size(batch_size)?;
@@ -164,16 +160,14 @@ unsafe fn add_columns_nulls_inner(
     schema: *const FFI_ArrowSchema,
 ) -> Result<i32> {
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
     if schema.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "schema must not be NULL".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "schema must not be NULL".into(),
+        ));
     }
 
     // SAFETY: `schema` is non-NULL (checked above) and the caller guarantees it
@@ -188,10 +182,9 @@ unsafe fn add_columns_nulls_inner(
     // zero-initialised or half-built struct that would slip past the release
     // check.
     if ffi_schema.release.is_none() || ffi_schema.format.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "schema is uninitialised or already released".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "schema is uninitialised or already released".into(),
+        ));
     }
     // arrow-rs's `FFI_ArrowSchema::format()` does `to_str().expect(..)` on the
     // format pointer; a non-NULL but non-UTF-8 top-level format would abort the
@@ -206,16 +199,15 @@ unsafe fn add_columns_nulls_inner(
         .to_str()
         .is_err()
     {
-        return Err(lance_core::Error::InvalidInput {
-            source: "schema format string is not valid UTF-8".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "schema format string is not valid UTF-8".into(),
+        ));
     }
-    let arrow_schema =
-        ArrowSchema::try_from(ffi_schema).map_err(|e| lance_core::Error::InvalidInput {
-            source: format!("schema is not a valid Arrow schema: {e}").into(),
-            location: location!(),
-        })?;
+    let arrow_schema = ArrowSchema::try_from(ffi_schema).map_err(|e| {
+        lance_core::Error::invalid_input_source(
+            format!("schema is not a valid Arrow schema: {e}").into(),
+        )
+    })?;
 
     let transform = NewColumnTransform::AllNulls(Arc::new(arrow_schema));
 
@@ -273,10 +265,9 @@ unsafe fn add_columns_stream_inner(
     // contract. (This NULL-before-`from_raw` ordering matches `merge_insert.rs`;
     // the callback pre-flight guard below is specific to this function.)
     if stream.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "stream must not be NULL".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "stream must not be NULL".into(),
+        ));
     }
 
     // Reject a stream missing a mandatory C Data Interface callback *before*
@@ -320,12 +311,11 @@ unsafe fn add_columns_stream_inner(
                 release_fn(stream);
             }
         }
-        return Err(lance_core::Error::InvalidInput {
-            source: "stream is uninitialised, already released, or missing a \
+        return Err(lance_core::Error::invalid_input_source(
+            "stream is uninitialised, already released, or missing a \
                      required get_schema/get_next/release callback"
                 .into(),
-            location: location!(),
-        });
+        ));
     }
 
     // SAFETY: `stream` is non-NULL (checked above) and the caller guarantees it
@@ -336,18 +326,13 @@ unsafe fn add_columns_stream_inner(
     // `release == NULL` error, but `from_raw` still fails (a live `map_err` path)
     // if the stream's `get_schema` callback returns an error code or yields a
     // schema arrow-rs cannot convert; that surfaces as `LANCE_ERR_INVALID_ARGUMENT`.
-    let reader = unsafe { ArrowArrayStreamReader::from_raw(stream) }.map_err(|e| {
-        lance_core::Error::InvalidInput {
-            source: e.to_string().into(),
-            location: location!(),
-        }
-    })?;
+    let reader = unsafe { ArrowArrayStreamReader::from_raw(stream) }
+        .map_err(|e| lance_core::Error::invalid_input_source(e.to_string().into()))?;
 
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
 
     let batch_size = resolve_batch_size(batch_size)?;
@@ -369,9 +354,10 @@ unsafe fn parse_required_field(ptr: *const c_char, index: usize, field: &str) ->
     // string the caller keeps alive for this call.
     let value = unsafe { helpers::parse_c_string(ptr)? }
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| lance_core::Error::InvalidInput {
-            source: format!("columns[{index}].{field} must not be NULL or empty").into(),
-            location: location!(),
+        .ok_or_else(|| {
+            lance_core::Error::invalid_input_source(
+                format!("columns[{index}].{field} must not be NULL or empty").into(),
+            )
         })?;
     Ok(value.to_string())
 }
@@ -383,9 +369,10 @@ fn resolve_batch_size(batch_size: u64) -> Result<Option<u32>> {
     if batch_size == 0 {
         return Ok(None);
     }
-    let narrowed = u32::try_from(batch_size).map_err(|_| lance_core::Error::InvalidInput {
-        source: format!("batch_size={batch_size} exceeds u32::MAX").into(),
-        location: location!(),
+    let narrowed = u32::try_from(batch_size).map_err(|_| {
+        lance_core::Error::invalid_input_source(
+            format!("batch_size={batch_size} exceeds u32::MAX").into(),
+        )
     })?;
     Ok(Some(narrowed))
 }

--- a/src/alter_columns.rs
+++ b/src/alter_columns.rs
@@ -15,7 +15,6 @@ use arrow::ffi::FFI_ArrowSchema;
 use arrow_schema::DataType;
 use lance::dataset::ColumnAlteration;
 use lance_core::Result;
-use snafu::location;
 
 use crate::dataset::LanceDataset;
 use crate::error::ffi_try;
@@ -48,13 +47,12 @@ impl LanceColumnNullableMode {
             0 => Ok(Self::Unchanged),
             1 => Ok(Self::True),
             2 => Ok(Self::False),
-            other => Err(lance_core::Error::InvalidInput {
-                source: format!(
+            other => Err(lance_core::Error::invalid_input_source(
+                format!(
                     "invalid nullable_mode {other}; expected 0..=2 (see LanceColumnNullableMode)"
                 )
                 .into(),
-                location: location!(),
-            }),
+            )),
         }
     }
 }
@@ -124,22 +122,19 @@ unsafe fn alter_columns_inner(
     num_alterations: usize,
 ) -> Result<i32> {
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
     if alterations.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "alterations must not be NULL".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "alterations must not be NULL".into(),
+        ));
     }
     if num_alterations == 0 {
-        return Err(lance_core::Error::InvalidInput {
-            source: "num_alterations must be > 0".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "num_alterations must be > 0".into(),
+        ));
     }
 
     // Materialize alterations up front so any per-index validation error
@@ -177,9 +172,10 @@ unsafe fn parse_alteration(
     // C string the caller keeps alive for this call.
     let path = unsafe { helpers::parse_c_string(entry.path)? }
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| lance_core::Error::InvalidInput {
-            source: format!("alterations[{index}].path must not be NULL or empty").into(),
-            location: location!(),
+        .ok_or_else(|| {
+            lance_core::Error::invalid_input_source(
+                format!("alterations[{index}].path must not be NULL or empty").into(),
+            )
         })?
         .to_string();
 
@@ -188,10 +184,9 @@ unsafe fn parse_alteration(
     let rename = unsafe { helpers::parse_c_string(entry.rename)? }
         .map(|s| {
             if s.is_empty() {
-                Err(lance_core::Error::InvalidInput {
-                    source: format!("alterations[{index}].rename must not be empty").into(),
-                    location: location!(),
-                })
+                Err(lance_core::Error::invalid_input_source(
+                    format!("alterations[{index}].rename must not be empty").into(),
+                ))
             } else {
                 Ok(s.to_string())
             }
@@ -219,30 +214,27 @@ unsafe fn parse_alteration(
         //   - `format == NULL`: catches a zero-initialised or otherwise
         //     half-built struct that would slip past the release check.
         if ffi_schema.release.is_none() || ffi_schema.format.is_null() {
-            return Err(lance_core::Error::InvalidInput {
-                source: format!(
-                    "alterations[{index}].data_type is uninitialised or already released"
-                )
-                .into(),
-                location: location!(),
-            });
+            return Err(lance_core::Error::invalid_input_source(
+                format!("alterations[{index}].data_type is uninitialised or already released")
+                    .into(),
+            ));
         }
-        let dt = DataType::try_from(ffi_schema).map_err(|e| lance_core::Error::InvalidInput {
-            source: format!("alterations[{index}].data_type is not a valid Arrow type: {e}").into(),
-            location: location!(),
+        let dt = DataType::try_from(ffi_schema).map_err(|e| {
+            lance_core::Error::invalid_input_source(
+                format!("alterations[{index}].data_type is not a valid Arrow type: {e}").into(),
+            )
         })?;
         Some(dt)
     };
 
     if rename.is_none() && nullable.is_none() && data_type.is_none() {
-        return Err(lance_core::Error::InvalidInput {
-            source: format!(
+        return Err(lance_core::Error::invalid_input_source(
+            format!(
                 "alterations[{index}] is a no-op: \
                  set rename, nullable_mode, or data_type to request a change"
             )
             .into(),
-            location: location!(),
-        });
+        ));
     }
 
     Ok(ColumnAlteration {

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -38,10 +38,9 @@ unsafe fn batch_to_arrow_inner(
     out_schema: *mut FFI_ArrowSchema,
 ) -> Result<i32> {
     if batch.is_null() || out_array.is_null() || out_schema.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "batch, out_array, and out_schema must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "batch, out_array, and out_schema must not be NULL".into(),
+        ));
     }
     let b = unsafe { &*batch };
     let struct_array: arrow_array::StructArray = b.inner.clone().into();

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -91,10 +91,9 @@ unsafe fn compact_inner(
     out_metrics: *mut LanceCompactionMetrics,
 ) -> Result<i32> {
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
 
     // SAFETY: `options` is either NULL (use defaults) or points to a valid
@@ -162,8 +161,9 @@ unsafe fn resolve_options(options: *const LanceCompactionOptions) -> Result<Comp
 /// Realistic compaction tunings fit in `usize` on every supported target,
 /// but a silent `as` cast would wrap on a 32-bit host.
 fn u64_to_usize(v: u64, field: &'static str) -> Result<usize> {
-    usize::try_from(v).map_err(|_| lance_core::Error::InvalidInput {
-        source: format!("{field}={v} exceeds usize::MAX on this target").into(),
-        location: snafu::location!(),
+    usize::try_from(v).map_err(|_| {
+        lance_core::Error::invalid_input_source(
+            format!("{field}={v} exceeds usize::MAX on this target").into(),
+        )
     })
 }

--- a/src/data_statistics.rs
+++ b/src/data_statistics.rs
@@ -42,10 +42,9 @@ pub unsafe extern "C" fn lance_dataset_calculate_data_stats(
 
 unsafe fn calculate_inner(dataset: *const LanceDataset) -> Result<*mut LanceDataStatistics> {
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
     // SAFETY: `dataset` is non-null (checked above) and points at a live
     // `LanceDataset` created by `lance_dataset_open`; we take only a shared

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -71,12 +71,8 @@ unsafe fn open_dataset_inner(
     storage_options: *const *const c_char,
     version: u64,
 ) -> Result<*mut LanceDataset> {
-    let uri_str = unsafe { helpers::parse_c_string(uri)? }.ok_or_else(|| {
-        lance_core::Error::InvalidInput {
-            source: "uri must not be NULL".into(),
-            location: snafu::location!(),
-        }
-    })?;
+    let uri_str = unsafe { helpers::parse_c_string(uri)? }
+        .ok_or_else(|| lance_core::Error::invalid_input_source("uri must not be NULL".into()))?;
 
     let opts = unsafe { helpers::parse_storage_options(storage_options)? };
 
@@ -184,10 +180,9 @@ unsafe fn dataset_schema_inner(
     out: *mut FFI_ArrowSchema,
 ) -> Result<i32> {
     if dataset.is_null() || out.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset and out must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset and out must not be NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
     let snap = ds.snapshot();
@@ -234,10 +229,9 @@ unsafe fn dataset_take_inner(
     out: *mut FFI_ArrowArrayStream,
 ) -> Result<i32> {
     if dataset.is_null() || indices.is_null() || out.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset, indices, and out must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset, indices, and out must not be NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
     let idx_slice = unsafe { std::slice::from_raw_parts(indices, num_indices) };

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -48,10 +48,9 @@ unsafe fn delete_inner(
     out_num_deleted: *mut u64,
 ) -> Result<i32> {
     if dataset.is_null() || predicate.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset and predicate must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset and predicate must not be NULL".into(),
+        ));
     }
 
     // SAFETY: `predicate` is non-NULL (checked above) and the caller
@@ -59,11 +58,8 @@ unsafe fn delete_inner(
     // duration of this call. `parse_c_string` reads by shared reference.
     let predicate_str = unsafe { helpers::parse_c_string(predicate)? }
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| lance_core::Error::InvalidInput {
-            // NULL is rejected above; only the empty case reaches here.
-            source: "predicate must not be empty".into(),
-            location: snafu::location!(),
-        })?;
+        // NULL is rejected above; only the empty case reaches here.
+        .ok_or_else(|| lance_core::Error::invalid_input("predicate must not be empty"))?;
 
     // SAFETY: `dataset` is non-NULL (checked above) and the caller guarantees
     // it points to a live `LanceDataset` not aliased mutably elsewhere.

--- a/src/drop_columns.rs
+++ b/src/drop_columns.rs
@@ -11,7 +11,6 @@
 use std::ffi::c_char;
 
 use lance_core::Result;
-use snafu::location;
 
 use crate::dataset::LanceDataset;
 use crate::error::ffi_try;
@@ -53,22 +52,19 @@ unsafe fn drop_columns_inner(
     num_columns: usize,
 ) -> Result<i32> {
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
     if columns.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "columns must not be NULL".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "columns must not be NULL".into(),
+        ));
     }
     if num_columns == 0 {
-        return Err(lance_core::Error::InvalidInput {
-            source: "num_columns must be > 0".into(),
-            location: location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "num_columns must be > 0".into(),
+        ));
     }
 
     // Materialize the column names up front so any per-index validation
@@ -83,9 +79,10 @@ unsafe fn drop_columns_inner(
         // NUL-terminated C string the caller keeps alive for this call.
         let name = unsafe { helpers::parse_c_string(entry)? }
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| lance_core::Error::InvalidInput {
-                source: format!("columns[{i}] must not be NULL or empty").into(),
-                location: location!(),
+            .ok_or_else(|| {
+                lance_core::Error::invalid_input_source(
+                    format!("columns[{i}] must not be NULL or empty").into(),
+                )
             })?;
         names.push(name.to_string());
     }

--- a/src/fragment_writer.rs
+++ b/src/fragment_writer.rs
@@ -75,47 +75,32 @@ unsafe fn write_fragments_inner(
     storage_opts: *const *const c_char,
 ) -> Result<i32> {
     if uri.is_null() || schema.is_null() || stream.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "uri, schema, and stream must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "uri, schema, and stream must not be NULL".into(),
+        ));
     }
 
-    let uri_str = unsafe { helpers::parse_c_string(uri)? }.ok_or_else(|| {
-        lance_core::Error::InvalidInput {
-            source: "uri must not be empty".into(),
-            location: snafu::location!(),
-        }
-    })?;
+    let uri_str = unsafe { helpers::parse_c_string(uri)? }
+        .ok_or_else(|| lance_core::Error::invalid_input_source("uri must not be empty".into()))?;
 
     // Import the caller-provided schema from the Arrow C Data Interface.
     let expected_schema = ArrowSchema::try_from(unsafe { &*schema }).map_err(|e| {
-        lance_core::Error::InvalidInput {
-            source: format!("invalid schema: {e}").into(),
-            location: snafu::location!(),
-        }
+        lance_core::Error::invalid_input_source(format!("invalid schema: {e}").into())
     })?;
 
     let opts = unsafe { helpers::parse_storage_options(storage_opts)? };
 
     // Consume the C stream into an Arrow RecordBatch reader.
-    let reader = unsafe { ArrowArrayStreamReader::from_raw(stream) }.map_err(|e| {
-        lance_core::Error::InvalidInput {
-            source: e.to_string().into(),
-            location: snafu::location!(),
-        }
-    })?;
+    let reader = unsafe { ArrowArrayStreamReader::from_raw(stream) }
+        .map_err(|e| lance_core::Error::invalid_input_source(e.to_string().into()))?;
 
     // Fail fast: compare the stream schema against the caller-provided schema.
     let stream_schema = reader.schema();
     if stream_schema.fields() != expected_schema.fields() {
-        return Err(lance_core::Error::InvalidInput {
-            source: format!(
+        return Err(lance_core::Error::invalid_input_source(format!(
                 "stream schema does not match the provided schema.\n  expected: {expected_schema}\n  got:      {stream_schema}"
             )
-            .into(),
-            location: snafu::location!(),
-        });
+            .into()));
     }
 
     let mut params = WriteParams::default();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,8 +6,7 @@
 use std::collections::HashMap;
 use std::ffi::{CStr, c_char};
 
-use lance_core::{Error, Result};
-use snafu::location;
+use lance_core::Result;
 
 /// Parse a nullable C string pointer into an `Option<&str>`.
 pub unsafe fn parse_c_string<'a>(ptr: *const c_char) -> Result<Option<&'a str>> {
@@ -15,10 +14,9 @@ pub unsafe fn parse_c_string<'a>(ptr: *const c_char) -> Result<Option<&'a str>> 
         return Ok(None);
     }
     let cstr = unsafe { CStr::from_ptr(ptr) };
-    let s = cstr.to_str().map_err(|e| Error::InvalidInput {
-        source: Box::new(e),
-        location: location!(),
-    })?;
+    let s = cstr
+        .to_str()
+        .map_err(|e| lance_core::Error::invalid_input_source(Box::new(e)))?;
     Ok(Some(s))
 }
 
@@ -62,10 +60,9 @@ pub unsafe fn parse_storage_options(ptr: *const *const c_char) -> Result<HashMap
         }
         let val_ptr = unsafe { *ptr.add(i + 1) };
         if val_ptr.is_null() {
-            return Err(Error::InvalidInput {
-                source: "storage options must be key-value pairs; odd number of entries".into(),
-                location: location!(),
-            });
+            return Err(lance_core::Error::invalid_input_source(
+                "storage options must be key-value pairs; odd number of entries".into(),
+            ));
         }
         let key = unsafe { parse_c_string(key_ptr)? }.unwrap().to_string();
         let val = unsafe { parse_c_string(val_ptr)? }.unwrap().to_string();

--- a/src/index.rs
+++ b/src/index.rs
@@ -35,10 +35,9 @@ impl LanceScalarIndexType {
             2 => Ok(Self::Bitmap),
             3 => Ok(Self::LabelList),
             4 => Ok(Self::Inverted),
-            _ => Err(lance_core::Error::InvalidInput {
-                source: format!("invalid scalar index type: {}", v).into(),
-                location: snafu::location!(),
-            }),
+            _ => Err(lance_core::Error::invalid_input_source(
+                format!("invalid scalar index type: {}", v).into(),
+            )),
         }
     }
 
@@ -95,17 +94,13 @@ unsafe fn create_scalar_index_inner(
     replace: bool,
 ) -> Result<i32> {
     if dataset.is_null() || column.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset and column must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset and column must not be NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
     let column_str = unsafe { helpers::parse_c_string(column)? }.ok_or_else(|| {
-        lance_core::Error::InvalidInput {
-            source: "column must not be empty".into(),
-            location: snafu::location!(),
-        }
+        lance_core::Error::invalid_input_source("column must not be empty".into())
     })?;
     let name = unsafe { helpers::parse_c_string(index_name)? }.map(|s| s.to_string());
     let params_str = unsafe { helpers::parse_c_string(params_json)? };
@@ -245,17 +240,13 @@ unsafe fn dataset_index_segments_inner(
     out_count: *mut u64,
 ) -> Result<i32> {
     if dataset.is_null() || index_name.is_null() || out_uuids.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset, index_name, and out_uuids must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset, index_name, and out_uuids must not be NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
     let name = unsafe { helpers::parse_c_string(index_name)? }.ok_or_else(|| {
-        lance_core::Error::InvalidInput {
-            source: "index_name must not be empty".into(),
-            location: snafu::location!(),
-        }
+        lance_core::Error::invalid_input_source("index_name must not be empty".into())
     })?;
     let snap = ds.snapshot();
     let indices = block_on(snap.load_indices())?;
@@ -264,21 +255,20 @@ unsafe fn dataset_index_segments_inner(
         .filter(|i| !lance_index::is_system_index(i) && i.name == name)
         .collect();
     if segments.is_empty() {
-        return Err(lance_core::Error::IndexNotFound {
-            identity: format!("name='{}'", name),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::index_not_found(format!(
+            "name='{}'",
+            name
+        )));
     }
     if segments.len() > capacity {
-        return Err(lance_core::Error::InvalidInput {
-            source: format!(
+        return Err(lance_core::Error::invalid_input_source(
+            format!(
                 "out_uuids capacity ({}) too small for {} segments",
                 capacity,
                 segments.len()
             )
             .into(),
-            location: snafu::location!(),
-        });
+        ));
     }
     // SAFETY: caller guarantees out_uuids has at least `capacity * 16` bytes,
     // and we verified `segments.len() <= capacity` above.
@@ -305,10 +295,9 @@ pub unsafe extern "C" fn lance_dataset_drop_index(
 
 unsafe fn drop_index_inner(dataset: *mut LanceDataset, name: *const c_char) -> Result<i32> {
     if dataset.is_null() || name.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset and name must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset and name must not be NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
     let name_str = unsafe { helpers::parse_c_string(name)? }.unwrap();
@@ -458,10 +447,9 @@ impl LanceMetricType {
 /// invalid value at the API boundary.
 fn require_field(name: &str, value: u32) -> Result<u32> {
     if value == 0 {
-        Err(lance_core::Error::InvalidInput {
-            source: format!("{} is required for this index type and must be > 0", name).into(),
-            location: snafu::location!(),
-        })
+        Err(lance_core::Error::invalid_input_source(
+            format!("{} is required for this index type and must be > 0", name).into(),
+        ))
     } else {
         Ok(value)
     }
@@ -588,17 +576,13 @@ unsafe fn create_vector_index_inner(
     replace: bool,
 ) -> Result<i32> {
     if dataset.is_null() || column.is_null() || params.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset, column, and params must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset, column, and params must not be NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
     let column_str = unsafe { helpers::parse_c_string(column)? }.ok_or_else(|| {
-        lance_core::Error::InvalidInput {
-            source: "column must not be empty".into(),
-            location: snafu::location!(),
-        }
+        lance_core::Error::invalid_input_source("column must not be empty".into())
     })?;
     let name = unsafe { helpers::parse_c_string(index_name)? }.map(|s| s.to_string());
     let p = unsafe { &*params };

--- a/src/merge_insert.rs
+++ b/src/merge_insert.rs
@@ -48,13 +48,10 @@ impl LanceMergeWhenMatched {
             2 => Ok(Self::UpdateIf),
             3 => Ok(Self::Fail),
             4 => Ok(Self::Delete),
-            other => Err(lance_core::Error::InvalidInput {
-                source: format!(
-                    "invalid when_matched {other}; expected 0..=4 (see LanceMergeWhenMatched)"
-                )
-                .into(),
-                location: snafu::location!(),
-            }),
+            other => Err(lance_core::Error::invalid_input_source(
+                format!("invalid when_matched {other}; expected 0..=4 (see LanceMergeWhenMatched)")
+                    .into(),
+            )),
         }
     }
 }
@@ -74,13 +71,10 @@ impl LanceMergeWhenNotMatched {
         match raw {
             0 => Ok(Self::InsertAll),
             1 => Ok(Self::DoNothing),
-            other => Err(lance_core::Error::InvalidInput {
-                source: format!(
+            other => Err(lance_core::Error::invalid_input_source(format!(
                     "invalid when_not_matched {other}; expected 0 or 1 (see LanceMergeWhenNotMatched)"
                 )
-                .into(),
-                location: snafu::location!(),
-            }),
+                .into())),
         }
     }
 }
@@ -104,13 +98,10 @@ impl LanceMergeWhenNotMatchedBySource {
             0 => Ok(Self::Keep),
             1 => Ok(Self::Delete),
             2 => Ok(Self::DeleteIf),
-            other => Err(lance_core::Error::InvalidInput {
-                source: format!(
+            other => Err(lance_core::Error::invalid_input_source(format!(
                     "invalid when_not_matched_by_source {other}; expected 0..=2 (see LanceMergeWhenNotMatchedBySource)"
                 )
-                .into(),
-                location: snafu::location!(),
-            }),
+                .into())),
         }
     }
 }
@@ -238,10 +229,9 @@ unsafe fn merge_insert_inner(
     // those paths and break the documented "consumed on every return"
     // contract (mirrors `lance_dataset_write`).
     if source.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "source stream must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "source stream must not be NULL".into(),
+        ));
     }
 
     // SAFETY: `source` is non-NULL (checked above) and the caller guarantees
@@ -249,30 +239,23 @@ unsafe fn merge_insert_inner(
     // owned by them. `from_raw` performs a `ptr::replace` that transfers
     // ownership into the returned reader, zeroing the caller's release
     // callback so it cannot be released twice.
-    let reader = unsafe { ArrowArrayStreamReader::from_raw(source) }.map_err(|e| {
-        lance_core::Error::InvalidInput {
-            source: e.to_string().into(),
-            location: snafu::location!(),
-        }
-    })?;
+    let reader = unsafe { ArrowArrayStreamReader::from_raw(source) }
+        .map_err(|e| lance_core::Error::invalid_input_source(e.to_string().into()))?;
 
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
     if num_on_columns == 0 {
-        return Err(lance_core::Error::InvalidInput {
-            source: "num_on_columns must be >= 1".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "num_on_columns must be >= 1".into(),
+        ));
     }
     if on_columns.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "on_columns must not be NULL when num_on_columns > 0".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "on_columns must not be NULL when num_on_columns > 0".into(),
+        ));
     }
 
     // Materialize key columns up front so a precise per-index error fires
@@ -286,9 +269,10 @@ unsafe fn merge_insert_inner(
         // NUL-terminated C string the caller keeps alive for this call.
         let key = unsafe { helpers::parse_c_string(entry_ptr)? }
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| lance_core::Error::InvalidInput {
-                source: format!("on_columns[{i}] must not be NULL or empty").into(),
-                location: snafu::location!(),
+            .ok_or_else(|| {
+                lance_core::Error::invalid_input_source(
+                    format!("on_columns[{i}] must not be NULL or empty").into(),
+                )
             })?;
         keys.push(key.to_string());
     }
@@ -384,9 +368,10 @@ unsafe fn resolve_params(params: *const LanceMergeInsertParams) -> Result<Resolv
             WhenMatched::UpdateAll
         }
         LanceMergeWhenMatched::UpdateIf => {
-            let expr = when_matched_expr.ok_or_else(|| lance_core::Error::InvalidInput {
-                source: "when_matched=UpdateIf requires when_matched_expr".into(),
-                location: snafu::location!(),
+            let expr = when_matched_expr.ok_or_else(|| {
+                lance_core::Error::invalid_input_source(
+                    "when_matched=UpdateIf requires when_matched_expr".into(),
+                )
             })?;
             // Upstream `WhenMatched::update_if` defers parsing until execute
             // time; we only forward the string here.
@@ -426,12 +411,10 @@ unsafe fn resolve_params(params: *const LanceMergeInsertParams) -> Result<Resolv
         }
         LanceMergeWhenNotMatchedBySource::DeleteIf => {
             let expr = when_not_matched_by_source_expr.ok_or_else(|| {
-                lance_core::Error::InvalidInput {
-                    source:
-                        "when_not_matched_by_source=DeleteIf requires when_not_matched_by_source_expr"
-                            .into(),
-                    location: snafu::location!(),
-                }
+                lance_core::Error::invalid_input_source(
+                    "when_not_matched_by_source=DeleteIf requires when_not_matched_by_source_expr"
+                        .into(),
+                )
             })?;
             ResolvedWhenNotMatchedBySource::DeleteIf(expr)
         }
@@ -453,20 +436,18 @@ unsafe fn read_optional_expr(ptr: *const c_char, field: &str) -> Result<Option<S
         return Ok(None);
     };
     if s.is_empty() {
-        return Err(lance_core::Error::InvalidInput {
-            source: format!("{field} must not be empty").into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            format!("{field} must not be empty").into(),
+        ));
     }
     Ok(Some(s.to_string()))
 }
 
 fn reject_unused_expr(field: &str, mode: &str, expr: &Option<String>) -> Result<()> {
     if expr.is_some() {
-        return Err(lance_core::Error::InvalidInput {
-            source: format!("{field}_expr must be NULL when {field}={mode}").into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            format!("{field}_expr must be NULL when {field}={mode}").into(),
+        ));
     }
     Ok(())
 }

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -41,16 +41,14 @@ pub unsafe extern "C" fn lance_dataset_restore(
 
 unsafe fn restore_inner(dataset: *const LanceDataset, version: u64) -> Result<*mut LanceDataset> {
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
     if version == 0 {
-        return Err(lance_core::Error::InvalidInput {
-            source: "version must be >= 1; 0 is reserved as the \"latest\" sentinel".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "version must be >= 1; 0 is reserved as the \"latest\" sentinel".into(),
+        ));
     }
 
     let ds = unsafe { &*dataset };

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -153,10 +153,9 @@ impl LanceScanner {
         }
         self.apply_fragment_filter(&mut scanner)?;
         if self.index_segments.is_some() && self.nearest.is_none() {
-            return Err(lance_core::Error::InvalidInput {
-                source: "index_segments requires nearest() to be configured".into(),
-                location: snafu::location!(),
-            });
+            return Err(lance_core::Error::invalid_input_source(
+                "index_segments requires nearest() to be configured".into(),
+            ));
         }
         if let Some(n) = &self.nearest {
             scanner.nearest(&n.column, n.query.as_ref(), n.k as usize)?;
@@ -214,10 +213,9 @@ impl LanceScanner {
         }
         self.apply_fragment_filter(&mut scanner)?;
         if self.index_segments.is_some() && self.nearest.is_none() {
-            return Err(lance_core::Error::InvalidInput {
-                source: "index_segments requires nearest() to be configured".into(),
-                location: snafu::location!(),
-            });
+            return Err(lance_core::Error::invalid_input_source(
+                "index_segments requires nearest() to be configured".into(),
+            ));
         }
         if let Some(n) = &self.nearest {
             scanner.nearest(&n.column, n.query.as_ref(), n.k as usize)?;
@@ -276,10 +274,9 @@ unsafe fn scanner_new_inner(
     filter: *const c_char,
 ) -> Result<*mut LanceScanner> {
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
     let col_names = unsafe { helpers::parse_c_string_array(columns)? };
@@ -458,10 +455,9 @@ unsafe fn scanner_to_arrow_stream_inner(
     out: *mut FFI_ArrowArrayStream,
 ) -> Result<i32> {
     if scanner.is_null() || out.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "scanner and out must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner and out must not be NULL".into(),
+        ));
     }
     let s = unsafe { &*scanner };
     let built_scanner = s.build_scanner()?;
@@ -895,24 +891,20 @@ unsafe fn scanner_nearest_inner(
     k: u32,
 ) -> Result<i32> {
     if scanner.is_null() || column.is_null() || query_data.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "scanner, column, and query_data must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner, column, and query_data must not be NULL".into(),
+        ));
     }
     if k == 0 {
-        return Err(lance_core::Error::InvalidInput {
-            source: "k must be > 0".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "k must be > 0".into(),
+        ));
     }
     let s = unsafe { &mut *scanner };
     if s.fts_query.is_some() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "cannot call nearest after full_text_search; they are mutually exclusive"
-                .into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "cannot call nearest after full_text_search; they are mutually exclusive".into(),
+        ));
     }
     let column_str = unsafe { helpers::parse_c_string(column)? }.unwrap();
 
@@ -923,10 +915,9 @@ unsafe fn scanner_nearest_inner(
         3 => LanceDataType::UInt8,
         4 => LanceDataType::Int8,
         _ => {
-            return Err(lance_core::Error::InvalidInput {
-                source: format!("invalid element_type: {}", element_type).into(),
-                location: snafu::location!(),
-            });
+            return Err(lance_core::Error::invalid_input_source(
+                format!("invalid element_type: {}", element_type).into(),
+            ));
         }
     };
 
@@ -998,20 +989,17 @@ unsafe fn fts_inner(
     max_fuzzy_distance: u32,
 ) -> Result<i32> {
     if scanner.is_null() || query.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "scanner and query must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner and query must not be NULL".into(),
+        ));
     }
     let s = unsafe { &mut *scanner };
 
     // Mutual exclusion with vector search.
     if s.nearest.is_some() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "cannot call full_text_search after nearest; they are mutually exclusive"
-                .into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "cannot call full_text_search after nearest; they are mutually exclusive".into(),
+        ));
     }
 
     let query_str = unsafe { helpers::parse_c_string(query)? }

--- a/src/update.rs
+++ b/src/update.rs
@@ -72,22 +72,19 @@ unsafe fn update_inner(
     out_num_updated: *mut u64,
 ) -> Result<i32> {
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
     if num_updates == 0 {
-        return Err(lance_core::Error::InvalidInput {
-            source: "num_updates must be >= 1".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "num_updates must be >= 1".into(),
+        ));
     }
     if columns.is_null() || values.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "columns and values must not be NULL when num_updates > 0".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "columns and values must not be NULL when num_updates > 0".into(),
+        ));
     }
 
     // Optional predicate. NULL means "update every row"; explicit empty
@@ -100,10 +97,9 @@ unsafe fn update_inner(
     if let Some(p) = predicate_str.as_ref()
         && p.is_empty()
     {
-        return Err(lance_core::Error::InvalidInput {
-            source: "predicate must not be empty (pass NULL to update all rows)".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "predicate must not be empty (pass NULL to update all rows)".into(),
+        ));
     }
 
     // Collect (column, value) pairs into owned strings up front so we can
@@ -119,15 +115,17 @@ unsafe fn update_inner(
         // to each entry pointer within the arrays.
         let col = unsafe { helpers::parse_c_string(col_ptr)? }
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| lance_core::Error::InvalidInput {
-                source: format!("columns[{i}] must not be NULL or empty").into(),
-                location: snafu::location!(),
+            .ok_or_else(|| {
+                lance_core::Error::invalid_input_source(
+                    format!("columns[{i}] must not be NULL or empty").into(),
+                )
             })?;
         let val = unsafe { helpers::parse_c_string(val_ptr)? }
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| lance_core::Error::InvalidInput {
-                source: format!("values[{i}] must not be NULL or empty").into(),
-                location: snafu::location!(),
+            .ok_or_else(|| {
+                lance_core::Error::invalid_input_source(
+                    format!("values[{i}] must not be NULL or empty").into(),
+                )
             })?;
         update_pairs.push((col.to_string(), val.to_string()));
     }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -34,10 +34,9 @@ pub unsafe extern "C" fn lance_dataset_versions(
 
 unsafe fn versions_inner(dataset: *const LanceDataset) -> Result<*mut LanceVersions> {
     if dataset.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "dataset must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset must not be NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
     let versions = block_on(ds.snapshot().versions())?;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -55,13 +55,12 @@ impl LanceWriteMode {
             0 => Ok(Self::Create),
             1 => Ok(Self::Append),
             2 => Ok(Self::Overwrite),
-            other => Err(lance_core::Error::InvalidInput {
-                source: format!(
+            other => Err(lance_core::Error::invalid_input_source(
+                format!(
                     "invalid write mode {other}; expected 0 (create), 1 (append), or 2 (overwrite)"
                 )
                 .into(),
-                location: snafu::location!(),
-            }),
+            )),
         }
     }
 }
@@ -180,10 +179,9 @@ unsafe fn write_dataset_inner(
     // uri/schema NULL checks ahead of `from_raw` would leak the stream on
     // those paths and break the documented "consumed on every return" contract.
     if stream.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "stream must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "stream must not be NULL".into(),
+        ));
     }
 
     // SAFETY: `stream` is non-NULL (checked above) and the caller guarantees
@@ -191,24 +189,18 @@ unsafe fn write_dataset_inner(
     // owned by them. `from_raw` performs a `ptr::replace` that transfers
     // ownership into the returned reader, zeroing the caller's release
     // callback so it cannot be released twice.
-    let reader = unsafe { ArrowArrayStreamReader::from_raw(stream) }.map_err(|e| {
-        lance_core::Error::InvalidInput {
-            source: e.to_string().into(),
-            location: snafu::location!(),
-        }
-    })?;
+    let reader = unsafe { ArrowArrayStreamReader::from_raw(stream) }
+        .map_err(|e| lance_core::Error::invalid_input_source(e.to_string().into()))?;
 
     if uri.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "uri must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "uri must not be NULL".into(),
+        ));
     }
     if schema.is_null() {
-        return Err(lance_core::Error::InvalidInput {
-            source: "schema must not be NULL".into(),
-            location: snafu::location!(),
-        });
+        return Err(lance_core::Error::invalid_input_source(
+            "schema must not be NULL".into(),
+        ));
     }
 
     // Validate the mode at the boundary — storing an out-of-range tag as a
@@ -222,21 +214,15 @@ unsafe fn write_dataset_inner(
     // which `block_on` enforces by completing before this function returns.
     let uri_str = unsafe { helpers::parse_c_string(uri)? }
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| lance_core::Error::InvalidInput {
-            // NULL is rejected above; only the empty case reaches here.
-            source: "uri must not be empty".into(),
-            location: snafu::location!(),
-        })?;
+        // NULL is rejected above; only the empty case reaches here.
+        .ok_or_else(|| lance_core::Error::invalid_input("uri must not be empty"))?;
 
     // SAFETY: `schema` is non-NULL (checked above) and the caller guarantees
     // it points to a properly-initialized `FFI_ArrowSchema` valid for the
     // duration of this call. `try_from(&FFI_ArrowSchema)` reads by shared
     // reference and does not move out of or release the schema.
     let expected_schema = ArrowSchema::try_from(unsafe { &*schema }).map_err(|e| {
-        lance_core::Error::InvalidInput {
-            source: format!("invalid schema: {e}").into(),
-            location: snafu::location!(),
-        }
+        lance_core::Error::invalid_input_source(format!("invalid schema: {e}").into())
     })?;
 
     // SAFETY: `storage_opts` is either NULL or a NULL-terminated array of
@@ -247,13 +233,10 @@ unsafe fn write_dataset_inner(
     // Fail fast: compare the stream schema against the caller-provided schema.
     let stream_schema = reader.schema();
     if stream_schema.fields() != expected_schema.fields() {
-        return Err(lance_core::Error::InvalidInput {
-            source: format!(
+        return Err(lance_core::Error::invalid_input_source(format!(
                 "stream schema does not match the provided schema.\n  expected: {expected_schema}\n  got:      {stream_schema}"
             )
-            .into(),
-            location: snafu::location!(),
-        });
+            .into()));
     }
 
     let store_params = (!opts.is_empty()).then(|| ObjectStoreParams {
@@ -316,15 +299,16 @@ unsafe fn apply_write_params(target: &mut WriteParams, params: &LanceWriteParams
         // of relying on `FromStr`'s generic "unknown version" path.
         let s = unsafe { helpers::parse_c_string(params.data_storage_version)? }
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| lance_core::Error::InvalidInput {
-                source: "data_storage_version must not be an empty string".into(),
-                location: snafu::location!(),
+            .ok_or_else(|| {
+                lance_core::Error::invalid_input_source(
+                    "data_storage_version must not be an empty string".into(),
+                )
             })?;
-        let version =
-            LanceFileVersion::from_str(s).map_err(|e| lance_core::Error::InvalidInput {
-                source: format!("invalid data_storage_version {s:?}: {e}").into(),
-                location: snafu::location!(),
-            })?;
+        let version = LanceFileVersion::from_str(s).map_err(|e| {
+            lance_core::Error::invalid_input_source(
+                format!("invalid data_storage_version {s:?}: {e}").into(),
+            )
+        })?;
         target.data_storage_version = Some(version);
     }
     target.enable_stable_row_ids = params.enable_stable_row_ids;
@@ -335,8 +319,9 @@ unsafe fn apply_write_params(target: &mut WriteParams, params: &LanceWriteParams
 /// Realistic write tunings fit in `usize` on every supported target, but a
 /// silent `as` cast would wrap on a 32-bit host.
 fn u64_to_usize(v: u64, field: &'static str) -> Result<usize> {
-    usize::try_from(v).map_err(|_| lance_core::Error::InvalidInput {
-        source: format!("{field}={v} exceeds usize::MAX on this target").into(),
-        location: snafu::location!(),
+    usize::try_from(v).map_err(|_| {
+        lance_core::Error::invalid_input_source(
+            format!("{field}={v} exceeds usize::MAX on this target").into(),
+        )
     })
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -15,6 +15,7 @@ use arrow::ffi::FFI_ArrowSchema;
 use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use arrow::record_batch::RecordBatchReader;
 use arrow_schema::Schema as ArrowSchema;
+use chrono::TimeDelta;
 use lance::Dataset;
 use lance::dataset::{AutoCleanupParams, WriteMode as LanceWriteModeUpstream, WriteParams};
 use lance_core::Result;
@@ -250,9 +251,14 @@ unsafe fn write_dataset_inner(
         // lance-c exposes neither cleanup configuration nor an explicit
         // cleanup operation, so losing the reclamation path would silently
         // accumulate versions for datasets created through the C writer.
-        // Preserve the pre-9.1 default (every 20 versions, older than 14
-        // days) to keep C-visible behavior unchanged across the upgrade.
-        auto_cleanup: Some(AutoCleanupParams::default()),
+        // Pin the pre-9.1 policy (every 20 versions, older than 14 days)
+        // explicitly rather than via `AutoCleanupParams::default()`, so a
+        // future upstream default change cannot silently shift C-visible
+        // behavior.
+        auto_cleanup: Some(AutoCleanupParams {
+            interval: 20,
+            older_than: TimeDelta::days(14),
+        }),
         ..WriteParams::default()
     };
     if !params.is_null() {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -16,7 +16,7 @@ use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use arrow::record_batch::RecordBatchReader;
 use arrow_schema::Schema as ArrowSchema;
 use lance::Dataset;
-use lance::dataset::{WriteMode as LanceWriteModeUpstream, WriteParams};
+use lance::dataset::{AutoCleanupParams, WriteMode as LanceWriteModeUpstream, WriteParams};
 use lance_core::Result;
 use lance_file::version::LanceFileVersion;
 use lance_io::object_store::{ObjectStoreParams, StorageOptionsAccessor};
@@ -246,6 +246,13 @@ unsafe fn write_dataset_inner(
     let mut write_params = WriteParams {
         mode: mode.into(),
         store_params,
+        // Lance 9.1 changed the upstream default to `auto_cleanup: None`.
+        // lance-c exposes neither cleanup configuration nor an explicit
+        // cleanup operation, so losing the reclamation path would silently
+        // accumulate versions for datasets created through the C writer.
+        // Preserve the pre-9.1 default (every 20 versions, older than 14
+        // days) to keep C-visible behavior unchanged across the upgrade.
+        auto_cleanup: Some(AutoCleanupParams::default()),
         ..WriteParams::default()
     };
     if !params.is_null() {

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -4066,6 +4066,45 @@ fn test_write_with_params_null_is_like_plain_write() {
 }
 
 #[test]
+fn test_write_preserves_auto_cleanup_default() {
+    // Lance 9.1 disabled auto-cleanup by default (auto_cleanup: None).
+    // lance-c exposes neither cleanup configuration nor an explicit cleanup
+    // operation, so the wrapper preserves the pre-9.1 default; datasets
+    // created through the C writer must keep their reclamation path.
+    let tmp = tempfile::tempdir().unwrap();
+    let uri = tmp.path().join("ds").to_str().unwrap().to_string();
+    let c_uri = c_str(&uri);
+
+    let ffi_schema = schema_to_ffi(&write_schema());
+    let mut stream = batch_to_ffi_stream(write_batch(vec![1, 2, 3], vec![1.0, 2.0, 3.0]));
+
+    let rc = unsafe {
+        lance_dataset_write_with_params(
+            c_uri.as_ptr(),
+            &ffi_schema,
+            &mut stream,
+            LanceWriteMode::Create as i32,
+            ptr::null(),
+            ptr::null(),
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, 0);
+
+    let dataset = lance_c::runtime::block_on(lance::Dataset::open(&uri)).unwrap();
+    let config = &dataset.manifest.config;
+    assert_eq!(
+        config.get("lance.auto_cleanup.interval").map(String::as_str),
+        Some("20"),
+        "auto-cleanup interval must be recorded in the manifest config"
+    );
+    assert!(
+        config.contains_key("lance.auto_cleanup.older_than"),
+        "auto-cleanup older_than must be recorded in the manifest config"
+    );
+}
+
+#[test]
 fn test_write_with_params_max_rows_per_file_splits_fragments() {
     let tmp = tempfile::tempdir().unwrap();
     let uri = tmp.path().join("ds").to_str().unwrap().to_string();

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -4094,12 +4094,17 @@ fn test_write_preserves_auto_cleanup_default() {
     let dataset = lance_c::runtime::block_on(lance::Dataset::open(&uri)).unwrap();
     let config = &dataset.manifest.config;
     assert_eq!(
-        config.get("lance.auto_cleanup.interval").map(String::as_str),
+        config
+            .get("lance.auto_cleanup.interval")
+            .map(String::as_str),
         Some("20"),
         "auto-cleanup interval must be recorded in the manifest config"
     );
-    assert!(
-        config.contains_key("lance.auto_cleanup.older_than"),
+    assert_eq!(
+        config
+            .get("lance.auto_cleanup.older_than")
+            .map(String::as_str),
+        Some("14days"),
         "auto-cleanup older_than must be recorded in the manifest config"
     );
 }
@@ -4942,9 +4947,9 @@ fn test_update_invalid_predicate_rejected() {
     let ds = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
 
     // Garbage SQL — UpdateBuilder::update_where wraps parser errors as
-    // InvalidInput, so this surfaces as InvalidArgument (different from
-    // lance_dataset_delete, which routes through a different upstream path
-    // and surfaces these as Internal).
+    // InvalidInput, so this surfaces as InvalidArgument (lance_dataset_delete
+    // classifies parser failures the same way under Lance 9.1; see
+    // test_delete_invalid_predicate_rejected).
     let pred = c_str("not a real predicate ((((");
     let cols = [c_str("value")];
     let vals = [c_str("0.0")];

--- a/tests/c_api_test.rs
+++ b/tests/c_api_test.rs
@@ -4435,10 +4435,8 @@ fn test_delete_invalid_predicate_rejected() {
     let pred = c_str("not a real predicate ((((");
     let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), ptr::null_mut()) };
     assert_eq!(rc, -1);
-    // Parser errors come back as Internal (this is what upstream surfaces;
-    // we don't try to re-classify them at the FFI boundary). If upstream
-    // ever tightens this to InvalidArgument, tighten this assertion too.
-    assert_eq!(lance_last_error_code(), LanceErrorCode::Internal);
+    // Lance 9.1 classifies parser failures as invalid user input.
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
     // The dataset is left untouched on the error path.
     assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
 
@@ -4454,8 +4452,7 @@ fn test_delete_unknown_column_rejected() {
     let pred = c_str("no_such_column = 1");
     let rc = unsafe { lance_dataset_delete(ds, pred.as_ptr(), ptr::null_mut()) };
     assert_eq!(rc, -1);
-    // Same upstream classification as malformed SQL — see note above.
-    assert_eq!(lance_last_error_code(), LanceErrorCode::Internal);
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
     assert_eq!(unsafe { lance_dataset_count_rows(ds) }, 3);
 
     unsafe { lance_dataset_close(ds) };
@@ -7732,13 +7729,8 @@ fn test_add_columns_sql_unknown_column_rejected() {
     let cols = [sql_column(&name, &expr)];
     let rc = unsafe { lance_dataset_add_columns_sql(ds, cols.as_ptr(), cols.len(), 0) };
     assert_eq!(rc, -1);
-    // A non-existent column is resolved by the lance-datafusion planner, which
-    // raises a schema error (`Error::Schema`) — the same upstream path as
-    // `lance_dataset_delete`'s unknown-column predicate. We don't re-classify
-    // it at the FFI boundary, so it surfaces as `Internal`, distinct from a
-    // *syntax* error, which the planner wraps as `InvalidInput`. If upstream
-    // ever tightens this to InvalidInput, tighten this assertion too.
-    assert_eq!(lance_last_error_code(), LanceErrorCode::Internal);
+    // Lance 9.1 classifies unknown expression columns as invalid user input.
+    assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
 
     unsafe { lance_dataset_close(ds) };
 }


### PR DESCRIPTION
## Summary

Upgrade the pinned Lance revision from `e0e977a6` (7.0.0-beta.7) to `e934cc2c` (9.1.0-beta.3), the core baseline used by the distributed index build track (#55). Split out of #57 so the engine upgrade lands (and can be reverted) independently of the feature work.

## What the upgrade forced

- **Error-constructor migration (the bulk of the diff).** lance-core error variants gained an implicit `backtrace` field, so direct struct construction (`Error::InvalidInput { source, location }`) no longer compiles. All FFI validation errors migrate to the new `Error::invalid_input` / `invalid_input_source` / `index_not_found` constructors. Variants and user-facing messages are unchanged; location (and now backtrace) are captured implicitly by snafu.
- **Three error-code assertions in c_api_test.rs.** Lance 9.1 classifies SQL parser failures and unknown expression columns as invalid user input (`InvalidArgument`) instead of `Internal`. The affected tests assert the new classification.
- **datafusion dev-dependency 53 → 54** to match the pinned Lance.
- **Auto-cleanup default preserved (gatekeeper finding).** Lance 9.1 flipped `WriteParams::auto_cleanup` from `Some(default)` to `None`. Because lance-c exposes neither cleanup configuration nor an explicit cleanup operation, that flip would silently remove the only C-visible reclamation path for datasets created through the C writer. The wrapper now sets `auto_cleanup` explicitly to the pre-9.1 default (every 20 versions, older than 14 days), so C-visible behavior is unchanged. Covered by `test_write_preserves_auto_cleanup_default`. A C cleanup API (`lance_dataset_cleanup_old_versions`, optional `LanceWriteParams` knobs) can be proposed as its own PR.

No public API, ABI, or behavior changes beyond the three reclassified error codes above.

## Validation

- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (257 tests)
- `cargo test --test compile_and_run_test -- --ignored --test-threads=1` (real C and C++ dynamic-link runs)

Tracks #55. The distributed index segment build PR (#57) is stacked on this change.

## Notes for reviewers

- The three reclassified error paths (`delete` malformed SQL / unknown column, `add_columns_sql` unknown column: `LANCE_ERR_INTERNAL` → `LANCE_ERR_INVALID_ARGUMENT`) are behavior changes visible to C callers; the public docs in `lance.h` / `lance.hpp` are updated accordingly. A `breaking-change` label may be warranted — maintainer's call.
- Related: #56 attempted a jump to 10.0.0 and was withdrawn. This PR stops at 9.1.0-beta.3, the baseline verified in #55 — which already contains the nullable FixedSizeList inner-null crash fix (lance-format/lance#7498, merged 2026-06-30) that motivated #56. A further move to 10.x can be evaluated as its own PR.

