### PR TITLE
feat: catch panics at the FFI boundary and report LANCE_ERR_PANIC (#61)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,6 +3716,7 @@ dependencies = [
  "lance-io",
  "lance-linalg",
  "lance-table",
+ "libc",
  "log",
  "pin-project",
  "snafu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,6 @@ tempfile = "3"
 # already in the graph transitively via tokio/lance.
 libc = "0.2"
 
-[profile.release]
-panic = "abort"
-
 [package.metadata.capi.header]
 subdirectory = "lance"
 generation = false  # we ship a hand-maintained header at include/lance/lance.h

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 arrow-array = "58.0.0"
 arrow-schema = "58.0.0"
 tempfile = "3"
+# Direct for `libc::SIGABRT` in the panic-guard test's child-process assertions;
+# already in the graph transitively via tokio/lance.
+libc = "0.2"
 
 [profile.release]
 panic = "abort"

--- a/include/lance/lance.h
+++ b/include/lance/lance.h
@@ -78,6 +78,8 @@ typedef enum {
     LANCE_ERR_INTERNAL = 6,
     LANCE_ERR_NOT_SUPPORTED = 7,
     LANCE_ERR_COMMIT_CONFLICT = 8,
+    /* An unexpected panic was caught at the FFI boundary. */
+    LANCE_ERR_PANIC = 9,
 } LanceErrorCode;
 
 /* ─── Index types (Phase 2) ─── */

--- a/include/lance/lance.h
+++ b/include/lance/lance.h
@@ -82,6 +82,30 @@ typedef enum {
     LANCE_ERR_PANIC = 9,
 } LanceErrorCode;
 
+/**
+ * Panic handling (issue lance-format/lance-c#61).
+ *
+ * A panic raised inside Lance/Arrow code is caught at the FFI boundary and
+ * reported as LANCE_ERR_PANIC through the usual thread-local error channel
+ * (lance_last_error_code / lance_last_error_message) instead of unwinding
+ * into the host. After a panic:
+ *
+ *  - A LanceScanner handle is poisoned: every later call on it fails with
+ *    LANCE_ERR_PANIC ("scanner is poisoned by an earlier panic"). Close it
+ *    and build a fresh scanner; do not retry the poisoned handle.
+ *  - A LanceDataset handle remains usable: commits are atomic manifest
+ *    swaps, and a mutation that panics before commit rolls back in memory,
+ *    leaving the last committed snapshot intact.
+ *
+ * Honest limits: a double panic, a panic in a destructor while unwinding, a
+ * stack overflow, or an allocation failure still aborts the process. A
+ * panic caught inside a close/free call (lance_*_close, lance_batch_free,
+ * lance_free_string) is logged and the remainder of the value may leak —
+ * close is best-effort by design. Post-panic process state is best-effort:
+ * hosts should fail the in-flight query rather than retry a poisoned
+ * handle.
+ */
+
 /* ─── Index types (Phase 2) ─── */
 
 typedef enum {
@@ -838,6 +862,12 @@ void lance_scanner_close(LanceScanner* scanner);
 
 /**
  * Materialize the scan as an ArrowArrayStream (blocking).
+ *
+ * Reading the exported stream may surface a mid-iteration panic as one
+ * error through the Arrow C stream contract (nonzero get_next plus
+ * get_last_error), followed by end-of-stream; the scanner handle is
+ * poisoned afterwards.
+ *
  * @return 0 on success, -1 on error
  */
 int32_t lance_scanner_to_arrow_stream(
@@ -861,6 +891,12 @@ int32_t lance_scanner_next(
 
 /**
  * Callback type for async operations.
+ *
+ * The callback runs on the dispatcher thread; on failure the error code and
+ * message are installed in that thread's thread-local storage immediately
+ * before the callback runs, so lance_last_error_* called from inside the
+ * callback observes this completion's failure. Callbacks must not panic.
+ *
  * @param ctx     Opaque pointer passed back from the caller
  * @param status  0 = success, -1 = error
  * @param result  Operation-specific result (e.g., ArrowArrayStream*)
@@ -870,6 +906,12 @@ typedef void (*LanceCallback)(void* ctx, int32_t status, void* result);
 /**
  * Start an async scan. The callback fires on a dedicated dispatcher thread
  * when the ArrowArrayStream is ready.
+ *
+ * On failure the callback receives status -1 with result NULL, and the
+ * error code/message are installed in the dispatcher thread's thread-local
+ * storage immediately before the callback runs (per completion). A panic in
+ * the scan task also yields status -1 with LANCE_ERR_PANIC and poisons the
+ * scanner handle.
  */
 void lance_scanner_scan_async(
     const LanceScanner* scanner,

--- a/include/lance/lance.h
+++ b/include/lance/lance.h
@@ -100,10 +100,16 @@ typedef enum {
  * Honest limits: a double panic, a panic in a destructor while unwinding, a
  * stack overflow, or an allocation failure still aborts the process. A
  * panic caught inside a close/free call (lance_*_close, lance_batch_free,
- * lance_free_string) is logged and the remainder of the value may leak —
+ * lance_free_string, or the release callback of an exported
+ * ArrowArrayStream) is logged and the remainder of the value may leak —
  * close is best-effort by design. Post-panic process state is best-effort:
  * hosts should fail the in-flight query rather than retry a poisoned
  * handle.
+ *
+ * Callbacks passed INTO the library (LanceCallback, LanceWaker) are the
+ * reverse direction and are NOT covered by this contract: their ABI is
+ * non-unwinding, so a panicking callback aborts the host process before
+ * the library can contain it. Callbacks must not panic.
  */
 
 /* ─── Index types (Phase 2) ─── */
@@ -895,7 +901,11 @@ int32_t lance_scanner_next(
  * The callback runs on the dispatcher thread; on failure the error code and
  * message are installed in that thread's thread-local storage immediately
  * before the callback runs, so lance_last_error_* called from inside the
- * callback observes this completion's failure. Callbacks must not panic.
+ * callback observes this completion's failure.
+ *
+ * Callbacks must not panic: the callback ABI is non-unwinding, so a
+ * panicking callback aborts the host process before the dispatcher can
+ * contain it.
  *
  * @param ctx     Opaque pointer passed back from the caller
  * @param status  0 = success, -1 = error

--- a/src/async_dispatcher.rs
+++ b/src/async_dispatcher.rs
@@ -8,7 +8,10 @@
 //! sequentially, avoiding reentrancy and Tokio thread blocking.
 
 use std::ffi::c_void;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::{LazyLock, mpsc};
+
+use crate::error::{LanceErrorCode, clear_last_error, panic_payload_message, set_last_error};
 
 /// C callback function pointer type for async operations.
 /// - `ctx`: opaque pointer passed back to the caller
@@ -25,6 +28,13 @@ pub(crate) struct DispatcherMessage {
     pub callback_ctx: *mut c_void,
     pub status: i32,
     pub result: *mut c_void,
+    /// Error to install on the dispatcher thread's TLS just before invoking
+    /// the callback: `Some((code, message))` on failure, `None` on success.
+    /// The error must travel inside the message itself (issue #61): an async
+    /// operation fails on a Tokio worker thread whose thread-local error the
+    /// callback can never observe, because the callback runs here, on the
+    /// dispatcher thread.
+    pub error: Option<(LanceErrorCode, String)>,
 }
 
 struct Dispatcher {
@@ -40,10 +50,29 @@ impl Dispatcher {
             .spawn(move || {
                 log::debug!("Lance C dispatcher thread started");
                 while let Ok(msg) = rx.recv() {
-                    // Invoke the C callback on this dedicated thread.
-                    // This ensures callbacks are serialized and don't run on Tokio I/O threads.
-                    unsafe {
+                    // Install the carried error on THIS thread's TLS so the
+                    // callback's `lance_last_error_*` calls observe it. TLS
+                    // persists across callbacks on this thread, so a success
+                    // must explicitly clear: a stale error from an earlier
+                    // failed callback must never leak into a later one.
+                    match &msg.error {
+                        Some((code, message)) => set_last_error(*code, message),
+                        None => clear_last_error(),
+                    }
+                    // Invoke the C callback under catch_unwind (issue #61): a
+                    // panicking callback — Rust host code in practice — must
+                    // not unwind this thread away. If it did, the channel
+                    // would disconnect and every later async completion would
+                    // be silently lost, hanging every future C caller waiting
+                    // for a callback that never fires. Log and keep dispatching.
+                    let outcome = catch_unwind(AssertUnwindSafe(|| unsafe {
                         (msg.callback)(msg.callback_ctx, msg.status, msg.result);
+                    }));
+                    if let Err(payload) = outcome {
+                        log::error!(
+                            "lance-c dispatcher: C callback panicked and was contained: {}",
+                            panic_payload_message(&*payload)
+                        );
                     }
                 }
                 log::debug!("Lance C dispatcher thread shutting down");
@@ -60,17 +89,186 @@ impl Dispatcher {
 
 static DISPATCHER: LazyLock<Dispatcher> = LazyLock::new(Dispatcher::new);
 
-/// Send a completion message to the dispatcher thread, which will invoke the callback.
+/// Send a completion message to the dispatcher thread. Before invoking the
+/// callback, the dispatcher installs `error` on its own thread-local error
+/// slot — `Some((code, message))` for failures, `None` (clearing any stale
+/// error) for successes — so `lance_last_error_*` called from inside the
+/// callback observes the outcome of THIS completion.
 pub(crate) fn dispatch_callback(
     callback: LanceCallback,
     callback_ctx: *mut c_void,
     status: i32,
     result: *mut c_void,
+    error: Option<(LanceErrorCode, String)>,
 ) {
     DISPATCHER.send(DispatcherMessage {
         callback,
         callback_ctx,
         status,
         result,
+        error,
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::{lance_free_string, lance_last_error_code, lance_last_error_message};
+    use std::ffi::CStr;
+    use std::ptr;
+    use std::time::Duration;
+
+    /// What a test callback observed on the dispatcher thread when it fired.
+    #[derive(Debug, PartialEq, Eq)]
+    struct Observation {
+        status: i32,
+        result_was_null: bool,
+        code: LanceErrorCode,
+        message: Option<String>,
+    }
+
+    struct CallbackProbe {
+        tx: mpsc::Sender<Observation>,
+    }
+
+    /// Records the callback arguments plus this thread's TLS error state, and
+    /// reports them back over the probe channel. Mirrors exactly what a C
+    /// consumer does on `status == -1`: read the code, then take the message.
+    unsafe extern "C" fn observe(ctx: *mut c_void, status: i32, result: *mut c_void) {
+        let probe = unsafe { &*(ctx as *const CallbackProbe) };
+        let code = lance_last_error_code();
+        let msg_ptr = lance_last_error_message();
+        let message = if msg_ptr.is_null() {
+            None
+        } else {
+            let msg = unsafe { CStr::from_ptr(msg_ptr) }
+                .to_string_lossy()
+                .into_owned();
+            unsafe { lance_free_string(msg_ptr) };
+            Some(msg)
+        };
+        let _ = probe.tx.send(Observation {
+            status,
+            result_was_null: result.is_null(),
+            code,
+            message,
+        });
+    }
+
+    fn probe() -> (mpsc::Receiver<Observation>, *mut c_void) {
+        let (tx, rx) = mpsc::channel();
+        let ctx = Box::into_raw(Box::new(CallbackProbe { tx })) as *mut c_void;
+        (rx, ctx)
+    }
+
+    unsafe fn reclaim(ctx: *mut c_void) {
+        unsafe {
+            drop(Box::from_raw(ctx as *mut CallbackProbe));
+        }
+    }
+
+    fn recv(rx: &mpsc::Receiver<Observation>) -> Observation {
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("dispatcher thread must deliver the callback within 5s")
+    }
+
+    #[test]
+    fn error_payload_is_installed_on_dispatcher_thread_tls() {
+        let (rx, ctx) = probe();
+        dispatch_callback(
+            observe,
+            ctx,
+            -1,
+            ptr::null_mut(),
+            Some((
+                LanceErrorCode::InvalidArgument,
+                "boom on the worker".to_string(),
+            )),
+        );
+
+        let obs = recv(&rx);
+        assert_eq!(obs.status, -1);
+        assert!(obs.result_was_null);
+        assert_eq!(
+            obs.code,
+            LanceErrorCode::InvalidArgument,
+            "callback must observe the carried error code on its own thread"
+        );
+        assert_eq!(obs.message.as_deref(), Some("boom on the worker"));
+
+        unsafe { reclaim(ctx) };
+    }
+
+    #[test]
+    fn success_clears_stale_error_from_earlier_failed_callback() {
+        let (rx, ctx) = probe();
+        // A failure followed by a success to the SAME callback: the second
+        // invocation must not see the first one's error, even though the
+        // dispatcher thread's TLS persists across callbacks.
+        dispatch_callback(
+            observe,
+            ctx,
+            -1,
+            ptr::null_mut(),
+            Some((LanceErrorCode::Internal, "first failure".to_string())),
+        );
+        dispatch_callback(observe, ctx, 0, ptr::dangling_mut::<c_void>(), None);
+
+        let first = recv(&rx);
+        assert_eq!(first.code, LanceErrorCode::Internal);
+        assert_eq!(first.message.as_deref(), Some("first failure"));
+
+        let second = recv(&rx);
+        assert_eq!(second.status, 0);
+        assert!(!second.result_was_null);
+        assert_eq!(
+            second.code,
+            LanceErrorCode::Ok,
+            "stale error must be cleared before a successful callback"
+        );
+        assert_eq!(second.message, None);
+
+        unsafe { reclaim(ctx) };
+    }
+
+    /// A callback that unwinds out of its frame. Declared `extern "C-unwind"`
+    /// because a panic in a plain `extern "C"` callback aborts at its own
+    /// boundary (Rust 1.81+) before any caller-side guard could run — the
+    /// dispatcher guard exists for Rust host callbacks like this one. The
+    /// cast to `LanceCallback` below is sound: "C" and "C-unwind" share the
+    /// same calling convention; only unwind permission differs.
+    unsafe extern "C-unwind" fn panicking_callback(
+        _ctx: *mut c_void,
+        _status: i32,
+        _result: *mut c_void,
+    ) {
+        panic!("simulated C callback panic")
+    }
+
+    #[test]
+    fn callback_panic_is_contained_and_dispatcher_survives() {
+        let (rx, ctx) = probe();
+        // Re-type the unwinding callback as the `extern "C"` LanceCallback.
+        // Sound: "C" and "C-unwind" share the same calling convention; only
+        // unwind permission differs, and the dispatcher is what catches it.
+        let unwinding_cb: LanceCallback = unsafe {
+            std::mem::transmute::<
+                unsafe extern "C-unwind" fn(*mut c_void, i32, *mut c_void),
+                LanceCallback,
+            >(panicking_callback)
+        };
+        // The panicking callback runs first; the normal one must still fire.
+        // (The panic hook prints to stderr during this test; expected noise.)
+        dispatch_callback(unwinding_cb, ptr::null_mut(), 0, ptr::null_mut(), None);
+        dispatch_callback(observe, ctx, 42, ptr::null_mut(), None);
+
+        let obs = recv(&rx);
+        assert_eq!(
+            obs.status, 42,
+            "a panicking callback must not kill the dispatcher thread"
+        );
+        assert_eq!(obs.code, LanceErrorCode::Ok);
+
+        unsafe { reclaim(ctx) };
+    }
 }

--- a/src/async_dispatcher.rs
+++ b/src/async_dispatcher.rs
@@ -59,18 +59,22 @@ impl Dispatcher {
                         Some((code, message)) => set_last_error(*code, message),
                         None => clear_last_error(),
                     }
-                    // Invoke the C callback under catch_unwind (issue #61): a
-                    // panicking callback — Rust host code in practice — must
-                    // not unwind this thread away. If it did, the channel
-                    // would disconnect and every later async completion would
-                    // be silently lost, hanging every future C caller waiting
-                    // for a callback that never fires. Log and keep dispatching.
+                    // Invoke the C callback under catch_unwind, best-effort
+                    // only (issue #61). The declared callback ABI is
+                    // `extern "C"` and therefore NON-unwinding — `lance.h`
+                    // requires callbacks not to panic, and a panic in such a
+                    // callback aborts at its own boundary before this catch
+                    // could ever run. The catch exists solely for Rust hosts
+                    // that pass an `extern "C-unwind"` callback: for them it
+                    // keeps the dispatcher thread (and with it every later
+                    // async completion) alive. It is not part of the panic
+                    // contract and must never be relied on as one.
                     let outcome = catch_unwind(AssertUnwindSafe(|| unsafe {
                         (msg.callback)(msg.callback_ctx, msg.status, msg.result);
                     }));
                     if let Err(payload) = outcome {
                         log::error!(
-                            "lance-c dispatcher: C callback panicked and was contained: {}",
+                            "lance-c dispatcher: unwinding (C-unwind) host callback panicked; contained best-effort: {}",
                             panic_payload_message(&*payload)
                         );
                     }
@@ -227,47 +231,6 @@ mod tests {
             "stale error must be cleared before a successful callback"
         );
         assert_eq!(second.message, None);
-
-        unsafe { reclaim(ctx) };
-    }
-
-    /// A callback that unwinds out of its frame. Declared `extern "C-unwind"`
-    /// because a panic in a plain `extern "C"` callback aborts at its own
-    /// boundary (Rust 1.81+) before any caller-side guard could run — the
-    /// dispatcher guard exists for Rust host callbacks like this one. The
-    /// cast to `LanceCallback` below is sound: "C" and "C-unwind" share the
-    /// same calling convention; only unwind permission differs.
-    unsafe extern "C-unwind" fn panicking_callback(
-        _ctx: *mut c_void,
-        _status: i32,
-        _result: *mut c_void,
-    ) {
-        panic!("simulated C callback panic")
-    }
-
-    #[test]
-    fn callback_panic_is_contained_and_dispatcher_survives() {
-        let (rx, ctx) = probe();
-        // Re-type the unwinding callback as the `extern "C"` LanceCallback.
-        // Sound: "C" and "C-unwind" share the same calling convention; only
-        // unwind permission differs, and the dispatcher is what catches it.
-        let unwinding_cb: LanceCallback = unsafe {
-            std::mem::transmute::<
-                unsafe extern "C-unwind" fn(*mut c_void, i32, *mut c_void),
-                LanceCallback,
-            >(panicking_callback)
-        };
-        // The panicking callback runs first; the normal one must still fire.
-        // (The panic hook prints to stderr during this test; expected noise.)
-        dispatch_callback(unwinding_cb, ptr::null_mut(), 0, ptr::null_mut(), None);
-        dispatch_callback(observe, ctx, 42, ptr::null_mut(), None);
-
-        let obs = recv(&rx);
-        assert_eq!(
-            obs.status, 42,
-            "a panicking callback must not kill the dispatcher thread"
-        );
-        assert_eq!(obs.code, LanceErrorCode::Ok);
 
         unsafe { reclaim(ctx) };
     }

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -9,7 +9,7 @@ use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use arrow_array::RecordBatch;
 use lance_core::Result;
 
-use crate::error::ffi_try;
+use crate::error::{ffi_try, swallow_unwind};
 
 /// Opaque handle wrapping an Arrow RecordBatch.
 pub struct LanceBatch {
@@ -53,11 +53,15 @@ unsafe fn batch_to_arrow_inner(
 }
 
 /// Free a `LanceBatch` handle.
+///
+/// Best-effort (issue #61): a panic raised while dropping the batch is
+/// caught and logged rather than unwinding into the caller, and the
+/// remainder of the value may leak.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_batch_free(batch: *mut LanceBatch) {
     if !batch.is_null() {
-        unsafe {
+        swallow_unwind("lance_batch_free", || unsafe {
             let _ = Box::from_raw(batch);
-        }
+        });
     }
 }

--- a/src/data_statistics.rs
+++ b/src/data_statistics.rs
@@ -12,7 +12,7 @@ use lance::dataset::statistics::DatasetStatisticsExt;
 use lance_core::Result;
 
 use crate::dataset::LanceDataset;
-use crate::error::ffi_try;
+use crate::error::{ffi_try, swallow_unwind};
 use crate::runtime::block_on;
 
 /// Opaque snapshot of a dataset's per-field data statistics.
@@ -123,12 +123,16 @@ unsafe fn bytes_on_disk_at_inner(stats: *const LanceDataStatistics, index: usize
 }
 
 /// Close and free a data statistics handle. Safe to call with NULL.
+///
+/// Best-effort (issue #61): a panic raised while dropping the handle is
+/// caught and logged rather than unwinding into the caller, and the
+/// remainder of the value may leak.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_data_statistics_close(stats: *mut LanceDataStatistics) {
     if !stats.is_null() {
-        unsafe {
+        swallow_unwind("lance_data_statistics_close", || unsafe {
             let _ = Box::from_raw(stats);
-        }
+        });
     }
 }
 

--- a/src/data_statistics.rs
+++ b/src/data_statistics.rs
@@ -12,7 +12,7 @@ use lance::dataset::statistics::DatasetStatisticsExt;
 use lance_core::Result;
 
 use crate::dataset::LanceDataset;
-use crate::error::{LanceErrorCode, clear_last_error, ffi_try, set_last_error};
+use crate::error::ffi_try;
 use crate::runtime::block_on;
 
 /// Opaque snapshot of a dataset's per-field data statistics.
@@ -71,17 +71,20 @@ unsafe fn calculate_inner(dataset: *const LanceDataset) -> Result<*mut LanceData
 /// distinguish the error case from an empty result.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_data_statistics_count(stats: *const LanceDataStatistics) -> u64 {
+    ffi_try!(unsafe { count_inner(stats) }, 0)
+}
+
+unsafe fn count_inner(stats: *const LanceDataStatistics) -> Result<u64> {
     if stats.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "stats is NULL");
-        return 0;
+        return Err(lance_core::Error::invalid_input_source(
+            "stats is NULL".into(),
+        ));
     }
     // SAFETY: `stats` is non-null (checked above) and was produced by
     // `lance_dataset_calculate_data_stats` via `Box::into_raw`; the accessors
     // only ever take shared borrows, so no mutable alias exists.
     let s = unsafe { &*stats };
-    let count = s.fields.len() as u64;
-    clear_last_error();
-    count
+    Ok(s.fields.len() as u64)
 }
 
 /// Return the schema field id at `index` (0 <= index < count).
@@ -95,7 +98,11 @@ pub unsafe extern "C" fn lance_data_statistics_field_id_at(
     stats: *const LanceDataStatistics,
     index: usize,
 ) -> u32 {
-    unsafe { entry_at(stats, index) }.map(|f| f.id).unwrap_or(0)
+    ffi_try!(unsafe { field_id_at_inner(stats, index) }, 0)
+}
+
+unsafe fn field_id_at_inner(stats: *const LanceDataStatistics, index: usize) -> Result<u32> {
+    Ok(unsafe { entry_at(stats, index) }?.id)
 }
 
 /// Return the compressed on-disk byte size of the field at `index`.
@@ -108,9 +115,11 @@ pub unsafe extern "C" fn lance_data_statistics_bytes_on_disk_at(
     stats: *const LanceDataStatistics,
     index: usize,
 ) -> u64 {
-    unsafe { entry_at(stats, index) }
-        .map(|f| f.bytes_on_disk)
-        .unwrap_or(0)
+    ffi_try!(unsafe { bytes_on_disk_at_inner(stats, index) }, 0)
+}
+
+unsafe fn bytes_on_disk_at_inner(stats: *const LanceDataStatistics, index: usize) -> Result<u64> {
+    Ok(unsafe { entry_at(stats, index) }?.bytes_on_disk)
 }
 
 /// Close and free a data statistics handle. Safe to call with NULL.
@@ -127,32 +136,26 @@ pub unsafe extern "C" fn lance_data_statistics_close(stats: *mut LanceDataStatis
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/// Copy the field stat at `index` out of the handle. Sets the thread-local
-/// error and returns `None` on NULL handle or out-of-range index.
-unsafe fn entry_at(stats: *const LanceDataStatistics, index: usize) -> Option<FieldStat> {
+/// Copy the field stat at `index` out of the handle. Returns an
+/// `InvalidArgument` error on NULL handle or out-of-range index.
+unsafe fn entry_at(stats: *const LanceDataStatistics, index: usize) -> Result<FieldStat> {
     if stats.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "stats is NULL");
-        return None;
+        return Err(lance_core::Error::invalid_input_source(
+            "stats is NULL".into(),
+        ));
     }
     // SAFETY: `stats` is non-null (checked above) and was produced by
     // `lance_dataset_calculate_data_stats` via `Box::into_raw`; we take only a
     // shared borrow.
     let s = unsafe { &*stats };
-    match s.fields.get(index).copied() {
-        Some(f) => {
-            clear_last_error();
-            Some(f)
-        }
-        None => {
-            set_last_error(
-                LanceErrorCode::InvalidArgument,
-                format!(
-                    "field statistics index {} out of range; count = {}",
-                    index,
-                    s.fields.len()
-                ),
-            );
-            None
-        }
-    }
+    s.fields.get(index).copied().ok_or_else(|| {
+        lance_core::Error::invalid_input_source(
+            format!(
+                "field statistics index {} out of range; count = {}",
+                index,
+                s.fields.len()
+            )
+            .into(),
+        )
+    })
 }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -4,6 +4,7 @@
 //! Dataset C API: open, close, metadata, schema, take.
 
 use std::ffi::c_char;
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::sync::{Arc, RwLock};
 
 use arrow::ffi::FFI_ArrowSchema;
@@ -25,20 +26,58 @@ pub struct LanceDataset {
 impl LanceDataset {
     /// Take a consistent snapshot of the inner dataset.
     /// Returns a cloned Arc so the caller can hold it without keeping the lock.
+    ///
+    /// Lock access is deliberately poison-tolerant. The lock is only ever
+    /// poisoned by a panic unwinding out of `with_mut`, and `with_mut` catches
+    /// that panic before swapping (see below), so the guarded value is always
+    /// a single consistent `Arc<Dataset>` pointer: it is never observed
+    /// half-mutated, and the swap itself is one atomic pointer store that
+    /// cannot tear. A poisoned lock therefore still protects consistent data,
+    /// and dataset handles stay usable after a caught panic.
     pub(crate) fn snapshot(&self) -> Arc<Dataset> {
-        self.inner.read().expect("dataset rwlock poisoned").clone()
+        self.inner.read().unwrap_or_else(|e| e.into_inner()).clone()
     }
 
-    /// Mutate the inner dataset under an exclusive write lock.
-    /// `Arc::make_mut` performs a cheap shallow clone if other Arc refs exist
-    /// (existing scanners keep their snapshot view).
+    /// Mutate the inner dataset under an exclusive write lock, using
+    /// clone-execute-swap so a panicking mutation cannot corrupt the handle:
+    ///
+    /// 1. `Dataset::clone` (a cheap shallow clone — every heap field of
+    ///    `Dataset` is an `Arc` or small value) copies the current dataset
+    ///    out of the lock.
+    /// 2. `f` runs on that clone, still under the write lock, so concurrent
+    ///    mutations stay serialized exactly as before. The call is wrapped in
+    ///    `catch_unwind`.
+    /// 3. On success the mutated clone replaces the stored `Arc` in one
+    ///    pointer swap and `f`'s return value is handed back.
+    /// 4. If `f` panics, the guard still holds the pristine old `Arc`, so the
+    ///    in-memory state is rolled back simply by never swapping. The panic
+    ///    is re-thrown via `resume_unwind` with its original payload so the
+    ///    entry-point `ffi_try!` guard maps it to `LANCE_ERR_PANIC` with the
+    ///    real message.
+    ///
+    /// Note this is deliberately *not* `Arc::make_mut` + restore-on-panic:
+    /// when the handle is the unique owner, `make_mut` mutates the shared
+    /// allocation in place, and "restoring" the old `Arc` would then restore
+    /// the same already-half-mutated dataset. Cloning first is the only form
+    /// that makes rollback real.
+    ///
+    /// The resumed unwind poisons the `RwLock`; the poison-tolerant accessors
+    /// are why the handle keeps working afterwards (per the issue consensus:
+    /// on-disk state cannot tear either, because Lance commits are atomic
+    /// manifest swaps).
     pub(crate) fn with_mut<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&mut Dataset) -> R,
     {
-        let mut guard = self.inner.write().expect("dataset rwlock poisoned");
-        let ds = Arc::make_mut(&mut *guard);
-        f(ds)
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        let mut working = Dataset::clone(&**guard);
+        match catch_unwind(AssertUnwindSafe(|| f(&mut working))) {
+            Ok(ret) => {
+                *guard = Arc::new(working);
+                ret
+            }
+            Err(payload) => resume_unwind(payload),
+        }
     }
 }
 
@@ -391,4 +430,89 @@ unsafe fn dataset_fragment_ids_inner(
         }
     }
     Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use arrow_array::{Int32Array, RecordBatch, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
+
+    /// Build a real 3-row dataset in a tempdir and wrap it in a handle.
+    /// (The default panic hook prints to stderr during the panic test; that
+    /// is expected noise.)
+    fn create_test_handle() -> (tempfile::TempDir, LanceDataset) {
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().join("with_mut_ds").to_str().unwrap().to_string();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+            ],
+        )
+        .unwrap();
+
+        let dataset = block_on(Dataset::write(
+            arrow::record_batch::RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &uri,
+            None,
+        ))
+        .unwrap();
+        let handle = LanceDataset {
+            inner: RwLock::new(Arc::new(dataset)),
+        };
+        (tmp, handle)
+    }
+
+    #[test]
+    fn with_mut_mutation_is_visible_via_snapshot() {
+        let (_tmp, handle) = create_test_handle();
+        assert_eq!(handle.snapshot().version().version, 1);
+
+        let result = handle.with_mut(|ds| block_on(ds.delete("id = 1")).unwrap());
+        assert_eq!(result.num_deleted_rows, 1);
+
+        let snap = handle.snapshot();
+        assert_eq!(snap.version().version, 2);
+        assert_eq!(block_on(snap.count_rows(None)).unwrap(), 2);
+    }
+
+    #[test]
+    fn with_mut_panic_rolls_back_and_handle_stays_usable() {
+        let (_tmp, handle) = create_test_handle();
+        let uri_before = handle.snapshot().uri().to_string();
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            handle.with_mut(|_ds| panic!("simulated bug in mutation"))
+        }));
+        let payload = result.expect_err("panic must escape with_mut unchanged");
+        let msg = crate::error::panic_payload_message(&*payload);
+        assert!(
+            msg.contains("simulated bug in mutation"),
+            "original payload must be preserved, got: {msg}"
+        );
+
+        // The unwind poisoned the RwLock; poison-tolerant reads must still
+        // return the pre-panic dataset (the swap never happened, so the
+        // in-memory state was rolled back).
+        let snap = handle.snapshot();
+        assert_eq!(snap.version().version, 1);
+        assert_eq!(snap.uri(), uri_before);
+        assert_eq!(block_on(snap.count_rows(None)).unwrap(), 3);
+
+        // A later mutation on the same handle still works (poison-tolerant
+        // write path) and is again visible via snapshot.
+        let result = handle.with_mut(|ds| block_on(ds.delete("id = 1")).unwrap());
+        assert_eq!(result.num_deleted_rows, 1);
+        let snap = handle.snapshot();
+        assert_eq!(snap.version().version, 2);
+        assert_eq!(block_on(snap.count_rows(None)).unwrap(), 2);
+    }
 }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -13,7 +13,7 @@ use lance::Dataset;
 use lance::dataset::builder::DatasetBuilder;
 use lance_core::Result;
 
-use crate::error::{LanceErrorCode, ffi_try, set_last_error};
+use crate::error::ffi_try;
 use crate::helpers;
 use crate::runtime::block_on;
 
@@ -127,56 +127,54 @@ pub unsafe extern "C" fn lance_dataset_close(dataset: *mut LanceDataset) {
 // ---------------------------------------------------------------------------
 
 /// Return the version number of this dataset snapshot.
+/// Returns 0 on error — check `lance_last_error_code()`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_dataset_version(dataset: *const LanceDataset) -> u64 {
+    ffi_try!(unsafe { dataset_version_inner(dataset) }, 0)
+}
+
+unsafe fn dataset_version_inner(dataset: *const LanceDataset) -> Result<u64> {
     if dataset.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "dataset is NULL");
-        return 0;
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset is NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
-    ds.snapshot().version().version
+    Ok(ds.snapshot().version().version)
 }
 
 /// Return the number of rows in the dataset.
 /// Returns 0 on error — check `lance_last_error_code()`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_dataset_count_rows(dataset: *const LanceDataset) -> u64 {
+    ffi_try!(unsafe { dataset_count_rows_inner(dataset) }, 0)
+}
+
+unsafe fn dataset_count_rows_inner(dataset: *const LanceDataset) -> Result<u64> {
     if dataset.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "dataset is NULL");
-        return 0;
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset is NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
-    match block_on(ds.snapshot().count_rows(None)) {
-        Ok(n) => {
-            crate::error::clear_last_error();
-            n as u64
-        }
-        Err(err) => {
-            crate::error::set_lance_error(&err);
-            0
-        }
-    }
+    Ok(block_on(ds.snapshot().count_rows(None))? as u64)
 }
 
 /// Return the latest version ID of the dataset.
 /// Returns 0 on error — check `lance_last_error_code()`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_dataset_latest_version(dataset: *const LanceDataset) -> u64 {
+    ffi_try!(unsafe { dataset_latest_version_inner(dataset) }, 0)
+}
+
+unsafe fn dataset_latest_version_inner(dataset: *const LanceDataset) -> Result<u64> {
     if dataset.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "dataset is NULL");
-        return 0;
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset is NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
-    match block_on(ds.snapshot().latest_version_id()) {
-        Ok(v) => {
-            crate::error::clear_last_error();
-            v
-        }
-        Err(err) => {
-            crate::error::set_lance_error(&err);
-            0
-        }
-    }
+    block_on(ds.snapshot().latest_version_id())
 }
 
 // ---------------------------------------------------------------------------
@@ -349,13 +347,17 @@ unsafe fn dataset_take_rows_inner(
 /// Returns 0 on error — check `lance_last_error_code()`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_dataset_fragment_count(dataset: *const LanceDataset) -> u64 {
+    ffi_try!(unsafe { dataset_fragment_count_inner(dataset) }, 0)
+}
+
+unsafe fn dataset_fragment_count_inner(dataset: *const LanceDataset) -> Result<u64> {
     if dataset.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "dataset is NULL");
-        return 0;
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset is NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
-    crate::error::clear_last_error();
-    ds.snapshot().count_fragments() as u64
+    Ok(ds.snapshot().count_fragments() as u64)
 }
 
 /// Fill `out_ids` with the fragment IDs of the dataset.
@@ -369,12 +371,17 @@ pub unsafe extern "C" fn lance_dataset_fragment_ids(
     dataset: *const LanceDataset,
     out_ids: *mut u64,
 ) -> i32 {
+    ffi_try!(unsafe { dataset_fragment_ids_inner(dataset, out_ids) }, neg)
+}
+
+unsafe fn dataset_fragment_ids_inner(
+    dataset: *const LanceDataset,
+    out_ids: *mut u64,
+) -> Result<i32> {
     if dataset.is_null() || out_ids.is_null() {
-        set_last_error(
-            LanceErrorCode::InvalidArgument,
-            "dataset and out_ids must not be NULL",
-        );
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset and out_ids must not be NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
     let fragments = ds.snapshot().get_fragments();
@@ -383,6 +390,5 @@ pub unsafe extern "C" fn lance_dataset_fragment_ids(
             *out_ids.add(i) = frag.id() as u64;
         }
     }
-    crate::error::clear_last_error();
-    0
+    Ok(0)
 }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -14,7 +14,7 @@ use lance::Dataset;
 use lance::dataset::builder::DatasetBuilder;
 use lance_core::Result;
 
-use crate::error::ffi_try;
+use crate::error::{ffi_try, swallow_unwind};
 use crate::helpers;
 use crate::runtime::block_on;
 
@@ -152,12 +152,17 @@ unsafe fn open_dataset_inner(
 
 /// Close and free a dataset handle.
 /// Safe to call with NULL. Safe to call multiple times (subsequent calls are no-ops).
+///
+/// Best-effort (issue #61): a panic raised while dropping the handle is
+/// caught and logged rather than unwinding into the caller, and the
+/// remainder of the value may leak. Deliberately no poison check — a
+/// poisoned handle must still be freeable.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_dataset_close(dataset: *mut LanceDataset) {
     if !dataset.is_null() {
-        unsafe {
+        swallow_unwind("lance_dataset_close", || unsafe {
             let _ = Box::from_raw(dataset);
-        }
+        });
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,8 @@ pub enum LanceErrorCode {
     Internal = 6,
     NotSupported = 7,
     CommitConflict = 8,
+    /// An unexpected panic was caught at the FFI boundary.
+    Panic = 9,
 }
 
 struct LastError {
@@ -73,6 +75,45 @@ pub fn set_lance_error(err: &lance_core::Error) {
     set_last_error(error_code_from_lance(err), err.to_string());
 }
 
+/// Extract a human-readable message from a `catch_unwind` panic payload.
+///
+/// `panic!` only ever produces `&str` or `String` payloads; anything else
+/// (e.g. from `std::panic::panic_any`) falls back to a fixed placeholder.
+/// NUL bytes are sanitized here once for all consumers: `set_last_error`
+/// sanitizes again internally, but other consumers — e.g. Arrow stream error
+/// strings built via `CString::new` — must never see a NUL.
+///
+/// Callers holding the `Box<dyn Any + Send>` from `catch_unwind` must pass
+/// `&*payload`, not `&payload`: the latter unsizes the *box itself* into the
+/// trait object, and the downcasts then never match.
+pub(crate) fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|s| (*s).to_owned())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "unknown panic payload".to_owned())
+        .replace('\0', "\\0")
+}
+
+/// Run `f` under `catch_unwind`, swallowing any panic after logging it.
+///
+/// For void close/free paths where the caller has no error signal: a panic
+/// must not unwind out of an `extern "C"` function (that aborts the host
+/// process under Rust 1.81+ semantics), so it is logged and dropped instead.
+/// Thread-local error state is deliberately left untouched — a void return
+/// gives the caller no channel to observe an error through anyway.
+// No non-test callers yet: the close/free entry points that need this get
+// their guards in the follow-up step of issue #61.
+#[allow(dead_code)]
+pub(crate) fn swallow_unwind(context: &str, f: impl FnOnce()) {
+    if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        log::error!(
+            "{context}: swallowed panic during unwinding: {}",
+            panic_payload_message(&*payload)
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Public C API
 // ---------------------------------------------------------------------------
@@ -114,33 +155,210 @@ pub unsafe extern "C" fn lance_free_string(s: *const c_char) {
 // Helper macro for FFI functions
 // ---------------------------------------------------------------------------
 
-/// Wrap an FFI function body: on error, set thread-local error and return $err_val.
-/// On success, clear the error and return the value.
+/// Wrap an FFI function body: run it under `catch_unwind`, then on success
+/// clear the thread-local error and return the value; on `lance_core::Error`
+/// set the thread-local error and return the shape's error value; on panic
+/// set a `LanceErrorCode::Panic` error carrying the panic message and return
+/// the shape's error value. Shapes: `null` (returns `*mut T`), `neg`
+/// (returns a signed integer, `-1` on error), `void` (returns `()`, error
+/// observable only via thread-local storage).
 macro_rules! ffi_try {
     ($body:expr, null) => {
-        match $body {
-            Ok(val) => {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| $body)) {
+            Ok(Ok(val)) => {
                 $crate::error::clear_last_error();
                 val
             }
-            Err(err) => {
+            Ok(Err(err)) => {
                 $crate::error::set_lance_error(&err);
+                std::ptr::null_mut()
+            }
+            Err(payload) => {
+                $crate::error::set_last_error(
+                    $crate::error::LanceErrorCode::Panic,
+                    format!(
+                        "panic in FFI call: {}",
+                        $crate::error::panic_payload_message(&*payload)
+                    ),
+                );
                 std::ptr::null_mut()
             }
         }
     };
     ($body:expr, neg) => {
-        match $body {
-            Ok(val) => {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| $body)) {
+            Ok(Ok(val)) => {
                 $crate::error::clear_last_error();
                 val
             }
-            Err(err) => {
+            Ok(Err(err)) => {
                 $crate::error::set_lance_error(&err);
                 -1
+            }
+            Err(payload) => {
+                $crate::error::set_last_error(
+                    $crate::error::LanceErrorCode::Panic,
+                    format!(
+                        "panic in FFI call: {}",
+                        $crate::error::panic_payload_message(&*payload)
+                    ),
+                );
+                -1
+            }
+        }
+    };
+    ($body:expr, void) => {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| $body)) {
+            Ok(Ok(_)) => {
+                $crate::error::clear_last_error();
+            }
+            Ok(Err(err)) => {
+                $crate::error::set_lance_error(&err);
+            }
+            Err(payload) => {
+                $crate::error::set_last_error(
+                    $crate::error::LanceErrorCode::Panic,
+                    format!(
+                        "panic in FFI call: {}",
+                        $crate::error::panic_payload_message(&*payload)
+                    ),
+                );
             }
         }
     };
 }
 
 pub(crate) use ffi_try;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+
+    /// Yields a `lance_core::Result<T>` by panicking — the panic is what the
+    /// `ffi_try!` shapes under test must catch. (The panic hook prints to
+    /// stderr during these tests; that is expected noise.)
+    fn panicking<T>() -> lance_core::Result<T> {
+        panic!("simulated bug in FFI body")
+    }
+
+    /// Take the pending thread-local error message, if any.
+    fn take_last_error_message() -> Option<String> {
+        let ptr = lance_last_error_message();
+        if ptr.is_null() {
+            None
+        } else {
+            let msg = unsafe { CStr::from_ptr(ptr) }
+                .to_string_lossy()
+                .into_owned();
+            unsafe { lance_free_string(ptr) };
+            Some(msg)
+        }
+    }
+
+    #[test]
+    fn panic_payload_message_str_payload() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new("boom");
+        assert_eq!(panic_payload_message(&*payload), "boom");
+    }
+
+    #[test]
+    fn panic_payload_message_string_payload() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new(String::from("boom"));
+        assert_eq!(panic_payload_message(&*payload), "boom");
+    }
+
+    #[test]
+    fn panic_payload_message_non_string_payload_falls_back() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new(42i32);
+        assert_eq!(panic_payload_message(&*payload), "unknown panic payload");
+    }
+
+    #[test]
+    fn panic_payload_message_sanitizes_nul() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new("bo\0om");
+        assert_eq!(panic_payload_message(&*payload), "bo\\0om");
+        let payload: Box<dyn std::any::Any + Send> = Box::new(String::from("\0"));
+        assert_eq!(panic_payload_message(&*payload), "\\0");
+    }
+
+    #[test]
+    fn ffi_try_null_maps_panic_to_null_and_panic_code() {
+        let ptr: *mut u8 = ffi_try!(panicking(), null);
+        assert!(ptr.is_null());
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Panic);
+        let msg = take_last_error_message().expect("panic must set a message");
+        assert!(
+            msg.contains("simulated bug in FFI body"),
+            "panic payload text must reach the error message, got: {msg}"
+        );
+
+        // A succeeding call clears the error.
+        let mut value = 7u8;
+        let ptr: *mut u8 = ffi_try!(Ok(&mut value as *mut u8), null);
+        assert_eq!(ptr, &mut value as *mut u8);
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Ok);
+        assert!(take_last_error_message().is_none());
+    }
+
+    #[test]
+    fn ffi_try_null_still_maps_lance_error() {
+        // Pre-existing behavior: Err(lance_core::Error) maps via
+        // error_code_from_lance, not via the Panic code.
+        let ptr: *mut u8 = ffi_try!(
+            Err(lance_core::Error::invalid_input_source("bad arg".into())),
+            null
+        );
+        assert!(ptr.is_null());
+        assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+        let msg = take_last_error_message().expect("error must set a message");
+        assert!(msg.contains("bad arg"), "got: {msg}");
+    }
+
+    #[test]
+    fn ffi_try_neg_maps_panic_to_minus_one_and_panic_code() {
+        let rc: i32 = ffi_try!(panicking(), neg);
+        assert_eq!(rc, -1);
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Panic);
+        let msg = take_last_error_message().expect("panic must set a message");
+        assert!(msg.contains("simulated bug in FFI body"), "got: {msg}");
+
+        // A succeeding call clears the error and returns the value.
+        let rc: i32 = ffi_try!(Ok(3i32), neg);
+        assert_eq!(rc, 3);
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Ok);
+    }
+
+    #[test]
+    fn ffi_try_void_maps_panic_to_panic_code() {
+        ffi_try!(panicking::<()>(), void);
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Panic);
+        let msg = take_last_error_message().expect("panic must set a message");
+        assert!(msg.contains("simulated bug in FFI body"), "got: {msg}");
+
+        // A succeeding call clears the error.
+        ffi_try!(lance_core::Result::<()>::Ok(()), void);
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Ok);
+    }
+
+    #[test]
+    fn swallow_unwind_swallows_panic_and_preserves_tls_error() {
+        set_last_error(LanceErrorCode::Internal, "marker error");
+        swallow_unwind("test context", || panic!("swallowed panic"));
+        // Returns normally, and the pre-existing error state is untouched.
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Internal);
+        let msg = take_last_error_message().expect("marker error must survive");
+        assert!(msg.contains("marker error"), "got: {msg}");
+        clear_last_error();
+    }
+
+    #[test]
+    fn swallow_unwind_runs_closure() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static CALLS: AtomicUsize = AtomicUsize::new(0);
+        swallow_unwind("test context", || {
+            CALLS.fetch_add(1, Ordering::SeqCst);
+        });
+        assert_eq!(CALLS.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -161,7 +161,11 @@ pub unsafe extern "C" fn lance_free_string(s: *const c_char) {
 /// set a `LanceErrorCode::Panic` error carrying the panic message and return
 /// the shape's error value. Shapes: `null` (returns `*mut T`), `neg`
 /// (returns a signed integer, `-1` on error), `void` (returns `()`, error
-/// observable only via thread-local storage).
+/// observable only via thread-local storage), or a generic `$errval`
+/// expression returned verbatim on either failure path (for 0-sentinel
+/// integer returns and any other shape the literal arms do not cover).
+/// The literal-token arms are listed first so `null`/`neg`/`void` are never
+/// captured by the `$errval:expr` catch-all.
 macro_rules! ffi_try {
     ($body:expr, null) => {
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| $body)) {
@@ -223,6 +227,28 @@ macro_rules! ffi_try {
                         $crate::error::panic_payload_message(&*payload)
                     ),
                 );
+            }
+        }
+    };
+    ($body:expr, $errval:expr) => {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| $body)) {
+            Ok(Ok(val)) => {
+                $crate::error::clear_last_error();
+                val
+            }
+            Ok(Err(err)) => {
+                $crate::error::set_lance_error(&err);
+                $errval
+            }
+            Err(payload) => {
+                $crate::error::set_last_error(
+                    $crate::error::LanceErrorCode::Panic,
+                    format!(
+                        "panic in FFI call: {}",
+                        $crate::error::panic_payload_message(&*payload)
+                    ),
+                );
+                $errval
             }
         }
     };
@@ -339,6 +365,43 @@ mod tests {
         // A succeeding call clears the error.
         ffi_try!(lance_core::Result::<()>::Ok(()), void);
         assert_eq!(lance_last_error_code(), LanceErrorCode::Ok);
+    }
+
+    #[test]
+    fn ffi_try_errval_ok_clears_and_returns_value() {
+        set_last_error(LanceErrorCode::Internal, "stale error");
+        let v: u64 = ffi_try!(Ok(42u64), 0);
+        assert_eq!(v, 42);
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Ok);
+        assert!(take_last_error_message().is_none());
+    }
+
+    #[test]
+    fn ffi_try_errval_maps_lance_error_to_errval_and_code() {
+        let v: u64 = ffi_try!(
+            Err(lance_core::Error::invalid_input_source("bad arg".into())),
+            0
+        );
+        assert_eq!(v, 0);
+        assert_eq!(lance_last_error_code(), LanceErrorCode::InvalidArgument);
+        let msg = take_last_error_message().expect("error must set a message");
+        assert!(msg.contains("bad arg"), "got: {msg}");
+    }
+
+    #[test]
+    fn ffi_try_errval_maps_panic_to_errval_and_panic_code() {
+        // A non-zero sentinel proves the arm returns `$errval` verbatim.
+        let v: i64 = ffi_try!(panicking(), 7);
+        assert_eq!(v, 7);
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Panic);
+        let msg = take_last_error_message().expect("panic must set a message");
+        assert!(msg.contains("simulated bug in FFI body"), "got: {msg}");
+
+        // The zero sentinel used by the 0-sentinel integer entry points.
+        let v: u32 = ffi_try!(panicking(), 0);
+        assert_eq!(v, 0);
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Panic);
+        take_last_error_message();
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,19 @@
 //!
 //! After any C function returns an error indicator (NULL pointer or negative int),
 //! the caller retrieves the error code and message from thread-local storage.
+//!
+//! Panic handling (issue #61): every entry point runs its body under
+//! `catch_unwind` (via `ffi_try!` or a hand-rolled guard), so a panic in
+//! Lance/Arrow code is reported as `LanceErrorCode::Panic` instead of
+//! unwinding across the FFI boundary. Scanner handles are poisoned after a
+//! panic and reject later calls; dataset handles stay usable because commits
+//! are atomic manifest swaps and failed mutations roll back in memory. Void
+//! close/free entry points have no error channel, so `swallow_unwind` catches
+//! a panicking `Drop`, logs it, and leaks the remainder by design. The limits
+//! are honest: double panics, panics in `Drop` during unwind, stack overflow,
+//! and allocation failure still abort the process, and post-panic state is
+//! best-effort — hosts should fail the query rather than retry a poisoned
+//! handle.
 
 use std::cell::RefCell;
 use std::ffi::{CString, c_char};
@@ -102,9 +115,6 @@ pub(crate) fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> Str
 /// process under Rust 1.81+ semantics), so it is logged and dropped instead.
 /// Thread-local error state is deliberately left untouched — a void return
 /// gives the caller no channel to observe an error through anyway.
-// No non-test callers yet: the close/free entry points that need this get
-// their guards in the follow-up step of issue #61.
-#[allow(dead_code)]
 pub(crate) fn swallow_unwind(context: &str, f: impl FnOnce()) {
     if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
         log::error!(
@@ -142,12 +152,16 @@ pub extern "C" fn lance_last_error_message() -> *const c_char {
 }
 
 /// Free a string returned by `lance_last_error_message()`.
+///
+/// Best-effort (issue #61): a panic raised while dropping the string is
+/// caught and logged rather than unwinding into the caller, and the
+/// allocation may leak.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_free_string(s: *const c_char) {
     if !s.is_null() {
-        unsafe {
+        swallow_unwind("lance_free_string", || unsafe {
             let _ = CString::from_raw(s as *mut c_char);
-        }
+        });
     }
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -14,7 +14,7 @@ use lance_index::IndexType;
 use lance_index::scalar::{BuiltinIndexType, ScalarIndexParams};
 
 use crate::dataset::LanceDataset;
-use crate::error::{LanceErrorCode, ffi_try, set_last_error};
+use crate::error::ffi_try;
 use crate::helpers;
 use crate::runtime::block_on;
 
@@ -126,27 +126,25 @@ unsafe fn create_scalar_index_inner(
 }
 
 /// Number of user indexes (excludes system indexes).
+/// Returns 0 on error — check `lance_last_error_code()`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_dataset_index_count(dataset: *const LanceDataset) -> u64 {
+    ffi_try!(unsafe { index_count_inner(dataset) }, 0)
+}
+
+unsafe fn index_count_inner(dataset: *const LanceDataset) -> Result<u64> {
     if dataset.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "dataset is NULL");
-        return 0;
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset is NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
     let snap = ds.snapshot();
-    match block_on(snap.load_indices()) {
-        Ok(indices) => {
-            crate::error::clear_last_error();
-            indices
-                .iter()
-                .filter(|i| !lance_index::is_system_index(i))
-                .count() as u64
-        }
-        Err(err) => {
-            crate::error::set_lance_error(&err);
-            0
-        }
-    }
+    let indices = block_on(snap.load_indices())?;
+    Ok(indices
+        .iter()
+        .filter(|i| !lance_index::is_system_index(i))
+        .count() as u64)
 }
 
 /// Count the segments that make up a logical index.
@@ -159,50 +157,35 @@ pub unsafe extern "C" fn lance_dataset_index_segment_count(
     dataset: *const LanceDataset,
     index_name: *const c_char,
 ) -> u64 {
+    ffi_try!(unsafe { index_segment_count_inner(dataset, index_name) }, 0)
+}
+
+unsafe fn index_segment_count_inner(
+    dataset: *const LanceDataset,
+    index_name: *const c_char,
+) -> Result<u64> {
     if dataset.is_null() || index_name.is_null() {
-        set_last_error(
-            LanceErrorCode::InvalidArgument,
-            "dataset and index_name must not be NULL",
-        );
-        return 0;
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset and index_name must not be NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
-    let name = match unsafe { helpers::parse_c_string(index_name) } {
-        Ok(Some(s)) => s,
-        Ok(None) => {
-            set_last_error(
-                LanceErrorCode::InvalidArgument,
-                "index_name must not be empty",
-            );
-            return 0;
-        }
-        Err(err) => {
-            crate::error::set_lance_error(&err);
-            return 0;
-        }
-    };
+    let name = unsafe { helpers::parse_c_string(index_name)? }.ok_or_else(|| {
+        lance_core::Error::invalid_input_source("index_name must not be empty".into())
+    })?;
     let snap = ds.snapshot();
-    match block_on(snap.load_indices()) {
-        Ok(indices) => {
-            let count = indices
-                .iter()
-                .filter(|i| !lance_index::is_system_index(i) && i.name == name)
-                .count();
-            if count == 0 {
-                set_last_error(
-                    LanceErrorCode::NotFound,
-                    format!("index '{}' not found", name),
-                );
-                return 0;
-            }
-            crate::error::clear_last_error();
-            count as u64
-        }
-        Err(err) => {
-            crate::error::set_lance_error(&err);
-            0
-        }
+    let indices = block_on(snap.load_indices())?;
+    let count = indices
+        .iter()
+        .filter(|i| !lance_index::is_system_index(i) && i.name == name)
+        .count();
+    if count == 0 {
+        return Err(lance_core::Error::index_not_found(format!(
+            "name='{}'",
+            name
+        )));
     }
+    Ok(count as u64)
 }
 
 /// Fill `out_uuids` with the UUIDs of the segments that make up a logical index.
@@ -311,66 +294,62 @@ unsafe fn drop_index_inner(dataset: *mut LanceDataset, name: *const c_char) -> R
 pub unsafe extern "C" fn lance_dataset_index_list_json(
     dataset: *const LanceDataset,
 ) -> *const c_char {
+    ffi_try!(unsafe { index_list_json_inner(dataset) }, null)
+}
+
+unsafe fn index_list_json_inner(dataset: *const LanceDataset) -> Result<*const c_char> {
     if dataset.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "dataset is NULL");
-        return std::ptr::null();
+        return Err(lance_core::Error::invalid_input_source(
+            "dataset is NULL".into(),
+        ));
     }
     let ds = unsafe { &*dataset };
     let snap = ds.snapshot();
 
-    let result = (|| -> Result<String> {
-        let indices = block_on(snap.load_indices())?;
-        let schema = snap.schema();
-        let descriptions = block_on(snap.describe_indices(None))?;
-        // Map name -> index_type string from describe_indices (one I/O batch)
-        let type_by_name: std::collections::HashMap<String, String> = descriptions
+    let indices = block_on(snap.load_indices())?;
+    let schema = snap.schema();
+    let descriptions = block_on(snap.describe_indices(None))?;
+    // Map name -> index_type string from describe_indices (one I/O batch)
+    let type_by_name: std::collections::HashMap<String, String> = descriptions
+        .iter()
+        .map(|d| (d.name().to_string(), d.index_type().to_string()))
+        .collect();
+
+    let mut entries: Vec<String> = Vec::new();
+    for idx in indices.iter() {
+        if lance_index::is_system_index(idx) {
+            continue;
+        }
+        let columns: Vec<String> = idx
+            .fields
             .iter()
-            .map(|d| (d.name().to_string(), d.index_type().to_string()))
+            .filter_map(|fid| schema.field_by_id(*fid).map(|f| f.name.clone()))
             .collect();
-
-        let mut entries: Vec<String> = Vec::new();
-        for idx in indices.iter() {
-            if lance_index::is_system_index(idx) {
-                continue;
-            }
-            let columns: Vec<String> = idx
-                .fields
-                .iter()
-                .filter_map(|fid| schema.field_by_id(*fid).map(|f| f.name.clone()))
-                .collect();
-            let type_str = type_by_name
-                .get(&idx.name)
-                .cloned()
-                .unwrap_or_else(|| "Unknown".to_string());
-            let cols_json = columns
-                .iter()
-                .map(|c| format!("\"{}\"", c.replace('"', "\\\"")))
-                .collect::<Vec<_>>()
-                .join(",");
-            entries.push(format!(
-                "{{\"name\":\"{}\",\"uuid\":\"{}\",\"columns\":[{}],\"type\":\"{}\",\"dataset_version\":{}}}",
-                idx.name.replace('"', "\\\""),
-                idx.uuid,
-                cols_json,
-                type_str,
-                idx.dataset_version,
-            ));
-        }
-        Ok(format!("[{}]", entries.join(",")))
-    })();
-
-    match result {
-        Ok(json) => {
-            crate::error::clear_last_error();
-            CString::new(json)
-                .map(|s| s.into_raw() as *const c_char)
-                .unwrap_or(std::ptr::null())
-        }
-        Err(err) => {
-            crate::error::set_lance_error(&err);
-            std::ptr::null()
-        }
+        let type_str = type_by_name
+            .get(&idx.name)
+            .cloned()
+            .unwrap_or_else(|| "Unknown".to_string());
+        let cols_json = columns
+            .iter()
+            .map(|c| format!("\"{}\"", c.replace('"', "\\\"")))
+            .collect::<Vec<_>>()
+            .join(",");
+        entries.push(format!(
+            "{{\"name\":\"{}\",\"uuid\":\"{}\",\"columns\":[{}],\"type\":\"{}\",\"dataset_version\":{}}}",
+            idx.name.replace('"', "\\\""),
+            idx.uuid,
+            cols_json,
+            type_str,
+            idx.dataset_version,
+        ));
     }
+    let json = format!("[{}]", entries.join(","));
+
+    // A JSON payload with an interior NUL cannot cross the C boundary as a
+    // `char*`; return NULL without an error message, as before.
+    Ok(CString::new(json)
+        .map(|s| s.into_raw() as *const c_char)
+        .unwrap_or(std::ptr::null()))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ mod merge_insert;
 mod restore;
 pub mod runtime;
 mod scanner;
+pub mod stream_guard;
 mod update;
 mod versions;
 mod writer;

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -18,7 +18,7 @@ use lance::dataset::scanner::DatasetRecordBatchStream;
 use lance_core::Result;
 use lance_index::scalar::FullTextSearchQuery;
 use lance_io::ffi::to_ffi_arrow_array_stream;
-use lance_io::stream::RecordBatchStream;
+use lance_io::stream::{RecordBatchStream, RecordBatchStreamAdapter};
 use uuid::Uuid;
 
 use crate::async_dispatcher::{self, LanceCallback};
@@ -30,6 +30,7 @@ use crate::error::{
 };
 use crate::helpers;
 use crate::runtime::{RT, block_on};
+use crate::stream_guard::GuardedStream;
 
 /// Data type tag for query vectors, mirroring the C enum `LanceDataType`.
 #[repr(i32)]
@@ -548,29 +549,70 @@ pub unsafe extern "C" fn lance_scanner_close(scanner: *mut LanceScanner) {
 /// This is the preferred API for simple integrations — blocks the calling thread.
 /// The scanner is consumed by this call and should not be used afterward (close it).
 ///
+/// The exported stream is panic-guarded (issue #61): a panic during export
+/// poisons the scanner — this call returns -1 with `LANCE_ERR_PANIC`, and
+/// every later call on the handle fails the same way — while a panic during
+/// later consumer-driven `get_next` calls surfaces as a stream error
+/// (nonzero `get_next` + `get_last_error`, then end-of-stream) instead of
+/// unwinding out of the Arrow C callbacks and aborting the host process.
+///
 /// Returns 0 on success, -1 on error.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_to_arrow_stream(
     scanner: *mut LanceScanner,
     out: *mut FFI_ArrowArrayStream,
 ) -> i32 {
+    if scanner.is_null() || out.is_null() {
+        set_last_error(
+            LanceErrorCode::InvalidArgument,
+            "scanner and out must not be NULL",
+        );
+        return -1;
+    }
     scanner_poison_check!(scanner, -1);
-    ffi_try!(unsafe { scanner_to_arrow_stream_inner(scanner, out) }, neg)
+    let s = unsafe { &*scanner };
+    let poisoned = s.poison_flag();
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        scanner_to_arrow_stream_inner(s, out)
+    })) {
+        Ok(Ok(rc)) => {
+            clear_last_error();
+            rc
+        }
+        Ok(Err(err)) => {
+            set_lance_error(&err);
+            -1
+        }
+        Err(payload) => {
+            poisoned.store(true, Ordering::SeqCst);
+            set_last_error(
+                LanceErrorCode::Panic,
+                format!("panic in FFI call: {}", panic_payload_message(&*payload)),
+            );
+            -1
+        }
+    }
 }
 
+/// Export logic, split out so `lance_scanner_to_arrow_stream` can wrap the
+/// whole thing in `catch_unwind` and poison the handle on panic. The stream
+/// is additionally wrapped in a [`GuardedStream`] before export so panics
+/// during the consumer's later `get_next` calls convert to a terminal stream
+/// error (and poison the handle) instead of unwinding across the Arrow C
+/// callbacks.
+///
+/// # Safety
+/// `out` must be a valid, writable pointer (checked by the caller).
 unsafe fn scanner_to_arrow_stream_inner(
-    scanner: *mut LanceScanner,
+    s: &LanceScanner,
     out: *mut FFI_ArrowArrayStream,
 ) -> Result<i32> {
-    if scanner.is_null() || out.is_null() {
-        return Err(lance_core::Error::invalid_input_source(
-            "scanner and out must not be NULL".into(),
-        ));
-    }
-    let s = unsafe { &*scanner };
     let built_scanner = s.build_scanner()?;
     let stream = block_on(built_scanner.try_into_stream())?;
-    let ffi_stream = to_ffi_arrow_array_stream(stream, RT.handle().clone())?;
+    let schema = stream.schema();
+    let guarded = GuardedStream::new(stream, s.poison_flag());
+    let adapted = RecordBatchStreamAdapter::new(schema, guarded);
+    let ffi_stream = to_ffi_arrow_array_stream(adapted, RT.handle().clone())?;
     unsafe {
         ptr::write_unaligned(out, ffi_stream);
     }
@@ -728,19 +770,31 @@ pub unsafe extern "C" fn lance_scanner_scan_async(
         ctx: callback_ctx,
     };
 
+    // Shared poison flag moved into the task: the GuardedStream below flips
+    // it if a panic is caught during the consumer's later `get_next` calls.
+    let poisoned = s.poison_flag();
+
     RT.spawn(async move {
         let result = built_scanner.try_into_stream().await;
         match result {
-            Ok(stream) => match to_ffi_arrow_array_stream(stream, handle) {
-                Ok(ffi_stream) => {
-                    let ptr = Box::into_raw(Box::new(ffi_stream));
-                    send_cb.dispatch(0, ptr as *mut c_void);
+            Ok(stream) => {
+                // Guard the exported stream (issue #61): a mid-iteration panic
+                // becomes one terminal error item per the Arrow C stream error
+                // contract instead of unwinding out of arrow-rs's `get_next`.
+                let schema = stream.schema();
+                let guarded = GuardedStream::new(stream, poisoned);
+                let adapted = RecordBatchStreamAdapter::new(schema, guarded);
+                match to_ffi_arrow_array_stream(adapted, handle) {
+                    Ok(ffi_stream) => {
+                        let ptr = Box::into_raw(Box::new(ffi_stream));
+                        send_cb.dispatch(0, ptr as *mut c_void);
+                    }
+                    Err(err) => {
+                        set_lance_error(&err);
+                        send_cb.dispatch(-1, std::ptr::null_mut());
+                    }
                 }
-                Err(err) => {
-                    set_lance_error(&err);
-                    send_cb.dispatch(-1, std::ptr::null_mut());
-                }
-            },
+            }
             Err(err) => {
                 set_lance_error(&err);
                 send_cb.dispatch(-1, std::ptr::null_mut());

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -17,8 +17,7 @@ use lance::Dataset;
 use lance::dataset::scanner::DatasetRecordBatchStream;
 use lance_core::Result;
 use lance_index::scalar::FullTextSearchQuery;
-use lance_io::ffi::to_ffi_arrow_array_stream;
-use lance_io::stream::{RecordBatchStream, RecordBatchStreamAdapter};
+use lance_io::stream::RecordBatchStream;
 use uuid::Uuid;
 
 use crate::async_dispatcher::{self, LanceCallback};
@@ -30,7 +29,7 @@ use crate::error::{
 };
 use crate::helpers;
 use crate::runtime::{RT, block_on};
-use crate::stream_guard::GuardedStream;
+use crate::stream_guard::GuardedReader;
 
 /// Data type tag for query vectors, mirroring the C enum `LanceDataType`.
 #[repr(i32)]
@@ -602,10 +601,12 @@ pub unsafe extern "C" fn lance_scanner_to_arrow_stream(
 
 /// Export logic, split out so `lance_scanner_to_arrow_stream` can wrap the
 /// whole thing in `catch_unwind` and poison the handle on panic. The stream
-/// is additionally wrapped in a [`GuardedStream`] before export so panics
-/// during the consumer's later `get_next` calls convert to a terminal stream
+/// is exported through a [`GuardedReader`] so panics during the consumer's
+/// later `get_next` calls — including a `Handle::block_on` panic on a
+/// consumer thread that is driving a Tokio runtime — convert to a terminal
+/// stream
 /// error (and poison the handle) instead of unwinding across the Arrow C
-/// callbacks.
+/// callbacks, and cleanup panics on the `release` path are contained.
 ///
 /// # Safety
 /// `out` must be a valid, writable pointer (checked by the caller).
@@ -616,9 +617,8 @@ unsafe fn scanner_to_arrow_stream_inner(
     let built_scanner = s.build_scanner()?;
     let stream = block_on(built_scanner.try_into_stream())?;
     let schema = stream.schema();
-    let guarded = GuardedStream::new(stream, s.poison_flag());
-    let adapted = RecordBatchStreamAdapter::new(schema, guarded);
-    let ffi_stream = to_ffi_arrow_array_stream(adapted, RT.handle().clone())?;
+    let reader = GuardedReader::new(stream, schema, RT.handle().clone(), s.poison_flag());
+    let ffi_stream = FFI_ArrowArrayStream::new(Box::new(reader));
     unsafe {
         ptr::write_unaligned(out, ffi_stream);
     }
@@ -725,12 +725,84 @@ unsafe fn scanner_next_inner(s: &mut LanceScanner, out: *mut *mut LanceBatch) ->
 /// The scanner configuration is captured at call time. The scanner handle
 /// can be closed immediately after this call.
 ///
-/// A panic inside the spawned task poisons the scanner and is still reported
-/// through the callback: `(ctx, -1, NULL)` with `LANCE_ERR_PANIC` on the
-/// callback thread's TLS — the caller never hangs waiting for a completion
-/// that would otherwise die as an unobserved task `JoinError`.
+/// The promised contract is exactly one callback completion, even on panic.
+/// A panic anywhere in call-time setup (validation, scanner building,
+/// runtime access, task spawn) is caught by the entry guard below and still
+/// reported through the callback: `(ctx, -1, NULL)` with `LANCE_ERR_PANIC`,
+/// and the scanner is poisoned. A panic inside the spawned task is caught by
+/// the task's own `catch_unwind().await` and reported the same way — the
+/// caller never hangs waiting for a completion that would otherwise die as
+/// an unobserved task `JoinError` or an unwinding abort.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_scan_async(
+    scanner: *const LanceScanner,
+    callback: LanceCallback,
+    callback_ctx: *mut c_void,
+) {
+    unsafe {
+        scan_async_guarded(scanner, callback, callback_ctx, |s, cb, ctx| {
+            scan_async_setup(s, cb, ctx)
+        });
+    }
+}
+
+/// Entry guard for `lance_scanner_scan_async` (issue #61): catches a panic
+/// anywhere in call-time setup so it cannot unwind out of the non-unwinding
+/// public entry point, then poisons the handle (when one was passed) and
+/// dispatches exactly one `LANCE_ERR_PANIC` completion. The setup closure is
+/// injectable so tests can exercise this guard without a production fault
+/// hook.
+///
+/// # Safety
+/// `scanner` must be NULL or a valid scanner handle; `callback` and
+/// `callback_ctx` follow the same contract as `lance_scanner_scan_async`.
+unsafe fn scan_async_guarded(
+    scanner: *const LanceScanner,
+    callback: LanceCallback,
+    callback_ctx: *mut c_void,
+    setup: impl FnOnce(*const LanceScanner, LanceCallback, *mut c_void),
+) {
+    // Capture the poison flag BEFORE setup runs: a panic during setup must
+    // still be able to poison the handle it never finished configuring.
+    let poison_flag = if scanner.is_null() {
+        None
+    } else {
+        Some(unsafe { &*scanner }.poison_flag())
+    };
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        setup(scanner, callback, callback_ctx)
+    }));
+    if let Err(payload) = outcome {
+        if let Some(flag) = poison_flag {
+            flag.store(true, Ordering::SeqCst);
+        }
+        // Best-effort: if even reporting panics (e.g. the dispatcher thread
+        // never started), swallow — a second panic unwinding out of this
+        // entry point would abort the host, which is what this guard exists
+        // to prevent.
+        swallow_unwind("lance_scanner_scan_async panic report", || {
+            async_dispatcher::dispatch_callback(
+                callback,
+                callback_ctx,
+                -1,
+                ptr::null_mut(),
+                Some((
+                    LanceErrorCode::Panic,
+                    format!("panic in FFI call: {}", panic_payload_message(&*payload)),
+                )),
+            );
+        });
+    }
+}
+
+/// Call-time setup plus task spawn for `lance_scanner_scan_async`, split out
+/// so the entry guard can wrap the whole thing in `catch_unwind`. Every
+/// handled failure delivers the `-1` callback itself; an escaped panic is
+/// the entry guard's job.
+///
+/// # Safety
+/// `scanner` must be NULL or a valid scanner handle (checked first).
+unsafe fn scan_async_setup(
     scanner: *const LanceScanner,
     callback: LanceCallback,
     callback_ctx: *mut c_void,
@@ -813,7 +885,7 @@ pub unsafe extern "C" fn lance_scanner_scan_async(
         ctx: callback_ctx,
     };
 
-    // Shared poison flag moved into the task: the GuardedStream below flips
+    // Shared poison flag moved into the task: the GuardedReader below flips
     // it if a panic is caught during the consumer's later `get_next` calls.
     let poisoned = s.poison_flag();
 
@@ -830,32 +902,25 @@ pub unsafe extern "C" fn lance_scanner_scan_async(
             let result = built_scanner.try_into_stream().await;
             match result {
                 Ok(stream) => {
-                    // Guard the exported stream (issue #61): a mid-iteration panic
-                    // becomes one terminal error item per the Arrow C stream error
-                    // contract instead of unwinding out of arrow-rs's `get_next`.
+                    // Guard the exported stream at the reader level (issue
+                    // #61): a mid-iteration panic — including a
+                    // `Handle::block_on` panic on a consumer thread driving a
+                    // Tokio runtime — becomes one terminal error item per
+                    // the Arrow C stream error contract instead of unwinding
+                    // out of arrow-rs's `get_next`, and cleanup panics on the
+                    // `release` path are contained.
                     let schema = stream.schema();
-                    let guarded = GuardedStream::new(stream, poisoned);
-                    let adapted = RecordBatchStreamAdapter::new(schema, guarded);
-                    match to_ffi_arrow_array_stream(adapted, handle) {
-                        Ok(ffi_stream) => {
-                            let ptr = Box::into_raw(Box::new(ffi_stream));
-                            send_cb.dispatch(0, ptr as *mut c_void, None);
-                        }
-                        Err(err) => {
-                            // Runs on a Tokio worker AFTER scan_async returned:
-                            // setting this thread's TLS would be invisible to
-                            // everyone, so the error rides inside the dispatch
-                            // message and the dispatcher installs it on the
-                            // callback thread instead (issue #61).
-                            send_cb.dispatch(
-                                -1,
-                                std::ptr::null_mut(),
-                                Some((error_code_from_lance(&err), err.to_string())),
-                            );
-                        }
-                    }
+                    let reader = GuardedReader::new(stream, schema, handle, poisoned);
+                    let ffi_stream = FFI_ArrowArrayStream::new(Box::new(reader));
+                    let ptr = Box::into_raw(Box::new(ffi_stream));
+                    send_cb.dispatch(0, ptr as *mut c_void, None);
                 }
                 Err(err) => {
+                    // Runs on a Tokio worker AFTER scan_async returned:
+                    // setting this thread's TLS would be invisible to
+                    // everyone, so the error rides inside the dispatch
+                    // message and the dispatcher installs it on the
+                    // callback thread instead (issue #61).
                     send_cb.dispatch(
                         -1,
                         std::ptr::null_mut(),
@@ -1604,6 +1669,92 @@ mod tests {
         assert!(batches > 0, "dataset must yield at least one batch");
 
         unsafe {
+            lance_scanner_close(scanner);
+            lance_dataset_close(dataset);
+        }
+    }
+
+    /// What the probe callback observed on the dispatcher thread: the
+    /// completion status plus the error the dispatcher installed on TLS.
+    #[derive(Debug)]
+    struct SetupPanicObservation {
+        status: i32,
+        code: LanceErrorCode,
+        message: Option<String>,
+    }
+
+    unsafe extern "C" fn record_setup_panic(ctx: *mut c_void, status: i32, _result: *mut c_void) {
+        let tx = unsafe { &*(ctx as *const std::sync::mpsc::Sender<SetupPanicObservation>) };
+        let code = lance_last_error_code();
+        let msg_ptr = lance_last_error_message();
+        let message = if msg_ptr.is_null() {
+            None
+        } else {
+            let msg = unsafe { CStr::from_ptr(msg_ptr) }
+                .to_string_lossy()
+                .into_owned();
+            unsafe { crate::error::lance_free_string(msg_ptr) };
+            Some(msg)
+        };
+        let _ = tx.send(SetupPanicObservation {
+            status,
+            code,
+            message,
+        });
+    }
+
+    /// Regression for the review finding that the spawned task's
+    /// `catch_unwind().await` started too late: a panic in *call-time setup*
+    /// (validation, `build_scanner`, runtime access, `RT.spawn`) used to
+    /// unwind out of the non-unwinding entry point and abort the host
+    /// without delivering the promised callback. The entry guard must poison
+    /// the handle and dispatch exactly one `LANCE_ERR_PANIC` completion
+    /// instead. The setup closure is injected so no production fault hook is
+    /// needed. (The panic hook prints to stderr; expected noise.)
+    #[test]
+    fn scan_async_setup_panic_poisons_and_dispatches_exactly_one_completion() {
+        let (_tmp, uri) = create_test_dataset();
+        let (dataset, scanner) = open_dataset_and_scanner(&uri);
+
+        let (tx, rx) = std::sync::mpsc::channel::<SetupPanicObservation>();
+        let ctx = Box::into_raw(Box::new(tx)) as *mut c_void;
+
+        unsafe {
+            scan_async_guarded(scanner, record_setup_panic, ctx, |_, _, _| {
+                panic!("injected setup panic")
+            });
+        }
+
+        assert!(
+            unsafe { &*scanner }.is_poisoned(),
+            "a setup panic must poison the scanner handle"
+        );
+
+        let obs = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("the entry guard must still deliver the callback");
+        assert_eq!(obs.status, -1);
+        assert_eq!(obs.code, LanceErrorCode::Panic);
+        assert!(
+            obs.message
+                .as_deref()
+                .expect("panic completion must carry a message")
+                .contains("injected setup panic"),
+            "panic payload must reach the callback, got: {:?}",
+            obs.message
+        );
+
+        // The contract is exactly ONE completion: no duplicate may follow.
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_millis(300))
+                .is_err(),
+            "a setup panic must dispatch exactly one callback completion"
+        );
+
+        unsafe {
+            drop(Box::from_raw(
+                ctx as *mut std::sync::mpsc::Sender<SetupPanicObservation>,
+            ));
             lance_scanner_close(scanner);
             lance_dataset_close(dataset);
         }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -26,7 +26,7 @@ use crate::batch::LanceBatch;
 use crate::dataset::LanceDataset;
 use crate::error::{
     LanceErrorCode, clear_last_error, error_code_from_lance, ffi_try, panic_payload_message,
-    set_lance_error, set_last_error,
+    set_lance_error, set_last_error, swallow_unwind,
 };
 use crate::helpers;
 use crate::runtime::{RT, block_on};
@@ -531,12 +531,18 @@ unsafe fn scanner_set_substrait_filter_inner(
 }
 
 /// Close and free a scanner handle.
+///
+/// Best-effort (issue #61): this drops a possibly-live
+/// `DatasetRecordBatchStream`, the highest-risk `Drop` in this crate. A
+/// panic raised while dropping the handle is caught and logged rather than
+/// unwinding into the caller, and the remainder of the value may leak.
+/// Deliberately no poison check — a poisoned scanner must still be freeable.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_close(scanner: *mut LanceScanner) {
     if !scanner.is_null() {
-        unsafe {
+        swallow_unwind("lance_scanner_close", || unsafe {
             let _ = Box::from_raw(scanner);
-        }
+        });
     }
 }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -12,7 +12,7 @@ use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 use arrow::ffi_stream::FFI_ArrowArrayStream;
 use arrow_schema::SchemaRef;
-use futures::{Stream, StreamExt};
+use futures::{FutureExt, Stream, StreamExt};
 use lance::Dataset;
 use lance::dataset::scanner::DatasetRecordBatchStream;
 use lance_core::Result;
@@ -25,8 +25,8 @@ use crate::async_dispatcher::{self, LanceCallback};
 use crate::batch::LanceBatch;
 use crate::dataset::LanceDataset;
 use crate::error::{
-    LanceErrorCode, clear_last_error, ffi_try, panic_payload_message, set_lance_error,
-    set_last_error,
+    LanceErrorCode, clear_last_error, error_code_from_lance, ffi_try, panic_payload_message,
+    set_lance_error, set_last_error,
 };
 use crate::helpers;
 use crate::runtime::{RT, block_on};
@@ -711,20 +711,36 @@ unsafe fn scanner_next_inner(s: &mut LanceScanner, out: *mut *mut LanceBatch) ->
 /// when the ArrowArrayStream is ready.
 ///
 /// - `callback`: Called with `(ctx, 0, *mut ArrowArrayStream)` on success,
-///   or `(ctx, -1, NULL)` on error (check `lance_last_error_*`).
+///   or `(ctx, -1, NULL)` on error. On error, the dispatcher installs the
+///   error on the callback thread's TLS first, so `lance_last_error_*`
+///   called from inside the callback observes the failure.
 /// - `callback_ctx`: Opaque pointer passed back to the callback.
 ///
 /// The scanner configuration is captured at call time. The scanner handle
 /// can be closed immediately after this call.
+///
+/// A panic inside the spawned task poisons the scanner and is still reported
+/// through the callback: `(ctx, -1, NULL)` with `LANCE_ERR_PANIC` on the
+/// callback thread's TLS — the caller never hangs waiting for a completion
+/// that would otherwise die as an unobserved task `JoinError`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_scan_async(
     scanner: *const LanceScanner,
     callback: LanceCallback,
     callback_ctx: *mut c_void,
 ) {
+    // Validation-time failures happen before scan_async returns, so they keep
+    // setting the caller thread's TLS AND carry the error inside the dispatch
+    // message for the callback thread to observe (issue #61).
     if scanner.is_null() {
         set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-        async_dispatcher::dispatch_callback(callback, callback_ctx, -1, ptr::null_mut());
+        async_dispatcher::dispatch_callback(
+            callback,
+            callback_ctx,
+            -1,
+            ptr::null_mut(),
+            Some((LanceErrorCode::InvalidArgument, "scanner is NULL".into())),
+        );
         return;
     }
 
@@ -736,7 +752,16 @@ pub unsafe extern "C" fn lance_scanner_scan_async(
             LanceErrorCode::Panic,
             "scanner is poisoned by an earlier panic",
         );
-        async_dispatcher::dispatch_callback(callback, callback_ctx, -1, ptr::null_mut());
+        async_dispatcher::dispatch_callback(
+            callback,
+            callback_ctx,
+            -1,
+            ptr::null_mut(),
+            Some((
+                LanceErrorCode::Panic,
+                "scanner is poisoned by an earlier panic".into(),
+            )),
+        );
         return;
     }
 
@@ -744,7 +769,13 @@ pub unsafe extern "C" fn lance_scanner_scan_async(
         Ok(sc) => sc,
         Err(err) => {
             set_lance_error(&err);
-            async_dispatcher::dispatch_callback(callback, callback_ctx, -1, ptr::null_mut());
+            async_dispatcher::dispatch_callback(
+                callback,
+                callback_ctx,
+                -1,
+                ptr::null_mut(),
+                Some((error_code_from_lance(&err), err.to_string())),
+            );
             return;
         }
     };
@@ -753,6 +784,7 @@ pub unsafe extern "C" fn lance_scanner_scan_async(
 
     // Wrap non-Send raw pointers for the async task.
     // Safety: The C caller guarantees callback_ctx remains valid until callback fires.
+    #[derive(Clone, Copy)]
     struct SendCallback {
         callback: LanceCallback,
         ctx: *mut c_void,
@@ -760,8 +792,13 @@ pub unsafe extern "C" fn lance_scanner_scan_async(
     unsafe impl Send for SendCallback {}
 
     impl SendCallback {
-        fn dispatch(&self, status: i32, result: *mut c_void) {
-            async_dispatcher::dispatch_callback(self.callback, self.ctx, status, result);
+        fn dispatch(
+            &self,
+            status: i32,
+            result: *mut c_void,
+            error: Option<(LanceErrorCode, String)>,
+        ) {
+            async_dispatcher::dispatch_callback(self.callback, self.ctx, status, result, error);
         }
     }
 
@@ -775,30 +812,64 @@ pub unsafe extern "C" fn lance_scanner_scan_async(
     let poisoned = s.poison_flag();
 
     RT.spawn(async move {
-        let result = built_scanner.try_into_stream().await;
-        match result {
-            Ok(stream) => {
-                // Guard the exported stream (issue #61): a mid-iteration panic
-                // becomes one terminal error item per the Arrow C stream error
-                // contract instead of unwinding out of arrow-rs's `get_next`.
-                let schema = stream.schema();
-                let guarded = GuardedStream::new(stream, poisoned);
-                let adapted = RecordBatchStreamAdapter::new(schema, guarded);
-                match to_ffi_arrow_array_stream(adapted, handle) {
-                    Ok(ffi_stream) => {
-                        let ptr = Box::into_raw(Box::new(ffi_stream));
-                        send_cb.dispatch(0, ptr as *mut c_void);
-                    }
-                    Err(err) => {
-                        set_lance_error(&err);
-                        send_cb.dispatch(-1, std::ptr::null_mut());
+        // Copies kept outside the inner future (which consumes the originals)
+        // so the panic arm below can still poison the handle and report.
+        let poisoned_on_panic = Arc::clone(&poisoned);
+        let send_cb_on_panic = send_cb;
+        // The whole task body runs under catch_unwind (issue #61): a panic
+        // here would otherwise die as an unobserved JoinError — the callback
+        // would never fire and the C caller would hang forever waiting for a
+        // completion that never arrives.
+        let outcome = std::panic::AssertUnwindSafe(async move {
+            let result = built_scanner.try_into_stream().await;
+            match result {
+                Ok(stream) => {
+                    // Guard the exported stream (issue #61): a mid-iteration panic
+                    // becomes one terminal error item per the Arrow C stream error
+                    // contract instead of unwinding out of arrow-rs's `get_next`.
+                    let schema = stream.schema();
+                    let guarded = GuardedStream::new(stream, poisoned);
+                    let adapted = RecordBatchStreamAdapter::new(schema, guarded);
+                    match to_ffi_arrow_array_stream(adapted, handle) {
+                        Ok(ffi_stream) => {
+                            let ptr = Box::into_raw(Box::new(ffi_stream));
+                            send_cb.dispatch(0, ptr as *mut c_void, None);
+                        }
+                        Err(err) => {
+                            // Runs on a Tokio worker AFTER scan_async returned:
+                            // setting this thread's TLS would be invisible to
+                            // everyone, so the error rides inside the dispatch
+                            // message and the dispatcher installs it on the
+                            // callback thread instead (issue #61).
+                            send_cb.dispatch(
+                                -1,
+                                std::ptr::null_mut(),
+                                Some((error_code_from_lance(&err), err.to_string())),
+                            );
+                        }
                     }
                 }
+                Err(err) => {
+                    send_cb.dispatch(
+                        -1,
+                        std::ptr::null_mut(),
+                        Some((error_code_from_lance(&err), err.to_string())),
+                    );
+                }
             }
-            Err(err) => {
-                set_lance_error(&err);
-                send_cb.dispatch(-1, std::ptr::null_mut());
-            }
+        })
+        .catch_unwind()
+        .await;
+        if let Err(payload) = outcome {
+            poisoned_on_panic.store(true, Ordering::SeqCst);
+            send_cb_on_panic.dispatch(
+                -1,
+                std::ptr::null_mut(),
+                Some((
+                    LanceErrorCode::Panic,
+                    format!("panic in FFI call: {}", panic_payload_message(&*payload)),
+                )),
+            );
         }
     });
 }
@@ -1433,10 +1504,29 @@ mod tests {
 
     static CALLBACK_STATUS: AtomicI32 = AtomicI32::new(i32::MIN);
     static CALLBACK_RESULT_WAS_NULL: AtomicBool = AtomicBool::new(false);
+    static CALLBACK_ERROR_CODE: AtomicI32 = AtomicI32::new(i32::MIN);
+    static CALLBACK_ERROR_MESSAGE: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 
     unsafe extern "C" fn record_status(_ctx: *mut c_void, status: i32, result: *mut c_void) {
-        CALLBACK_STATUS.store(status, Ordering::SeqCst);
         CALLBACK_RESULT_WAS_NULL.store(result.is_null(), Ordering::SeqCst);
+        // The dispatcher installs the error on this (callback) thread's TLS
+        // before invoking us; record it exactly as a C consumer reads it:
+        // code first, then the (consuming) message read.
+        CALLBACK_ERROR_CODE.store(lance_last_error_code() as i32, Ordering::SeqCst);
+        let msg_ptr = lance_last_error_message();
+        let message = if msg_ptr.is_null() {
+            None
+        } else {
+            let msg = unsafe { CStr::from_ptr(msg_ptr) }
+                .to_string_lossy()
+                .into_owned();
+            unsafe { crate::error::lance_free_string(msg_ptr) };
+            Some(msg)
+        };
+        *CALLBACK_ERROR_MESSAGE.lock().unwrap() = message;
+        // Published last: a reader that observes `status` also observes the
+        // error fields written above (SeqCst total order).
+        CALLBACK_STATUS.store(status, Ordering::SeqCst);
     }
 
     #[test]
@@ -1458,6 +1548,23 @@ mod tests {
         }
         assert_eq!(CALLBACK_STATUS.load(Ordering::SeqCst), -1);
         assert!(CALLBACK_RESULT_WAS_NULL.load(Ordering::SeqCst));
+        // The callback thread's TLS must carry the poison error too (issue
+        // #61): validation-time failures set the caller thread's TLS AND ride
+        // inside the dispatch message, which the dispatcher installs before
+        // invoking the callback.
+        assert_eq!(
+            CALLBACK_ERROR_CODE.load(Ordering::SeqCst),
+            LanceErrorCode::Panic as i32
+        );
+        let callback_msg = CALLBACK_ERROR_MESSAGE
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("callback-thread TLS must carry the poison message");
+        assert!(
+            callback_msg.contains("poisoned by an earlier panic"),
+            "unexpected callback-thread message: {callback_msg}"
+        );
 
         unsafe {
             lance_scanner_close(scanner);

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -7,6 +7,7 @@ use std::ffi::{c_char, c_void};
 use std::pin::Pin;
 use std::ptr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 use arrow::ffi_stream::FFI_ArrowArrayStream;
@@ -23,7 +24,10 @@ use uuid::Uuid;
 use crate::async_dispatcher::{self, LanceCallback};
 use crate::batch::LanceBatch;
 use crate::dataset::LanceDataset;
-use crate::error::{LanceErrorCode, clear_last_error, ffi_try, set_lance_error, set_last_error};
+use crate::error::{
+    LanceErrorCode, clear_last_error, ffi_try, panic_payload_message, set_lance_error,
+    set_last_error,
+};
 use crate::helpers;
 use crate::runtime::{RT, block_on};
 
@@ -58,6 +62,13 @@ pub struct LanceScanner {
     use_index: Option<bool>,
     prefilter: bool,
     fts_query: Option<FullTextSearchQuery>,
+    // Set when a panic is caught in a stateful stream operation (issue #61):
+    // once poisoned, every later `lance_scanner_*` call on this handle (except
+    // `lance_scanner_close`, which must always free memory) fails with
+    // `LANCE_ERR_PANIC`. Behind an `Arc` so the exported-stream wrapper and
+    // the spawned async task can poison the handle from outside this call
+    // frame via `poison_flag()`.
+    poisoned: Arc<AtomicBool>,
     // Materialized on first iteration call
     stream: Option<Pin<Box<DatasetRecordBatchStream>>>,
     #[allow(dead_code)]
@@ -110,9 +121,23 @@ impl LanceScanner {
             use_index: None,
             prefilter: false,
             fts_query: None,
+            poisoned: Arc::new(AtomicBool::new(false)),
             stream: None,
             schema: None,
         }
+    }
+
+    /// Whether a panic was caught in an earlier stateful operation on this
+    /// scanner. Checked by every `lance_scanner_*` entry point except close.
+    fn is_poisoned(&self) -> bool {
+        self.poisoned.load(Ordering::SeqCst)
+    }
+
+    /// Clone of the shared poison flag, for wiring into the exported Arrow
+    /// stream wrapper and the async scan task (later steps of issue #61) so a
+    /// panic caught there marks this handle unusable for later calls.
+    pub(crate) fn poison_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.poisoned)
     }
 
     /// Apply fragment selection to a scanner builder if fragment_ids is set.
@@ -254,6 +279,36 @@ impl LanceScanner {
 }
 
 // ---------------------------------------------------------------------------
+// Poison check shared by all `lance_scanner_*` entry points
+// ---------------------------------------------------------------------------
+
+/// Reject calls on a scanner handle that was poisoned by an earlier panic
+/// (issue #61). Applies to every `lance_scanner_*` entry point that
+/// dereferences the handle — setters included, since they are still "later
+/// calls on a poisoned handle" — EXCEPT the void close/free path, which must
+/// always be able to free memory.
+///
+/// The check runs only when the pointer is non-NULL, so a NULL handle keeps
+/// flowing into the normal NULL-argument error path (observably, the poison
+/// check sits right after the handle NULL check). A poisoned handle is
+/// unusable, so the check precedes validation of any other arguments.
+///
+/// The poison error code must be `LanceErrorCode::Panic`, which a plain
+/// `lance_core::Error` cannot express, so this sets the thread-local error
+/// and returns `$errval` directly instead of going through `ffi_try!`.
+macro_rules! scanner_poison_check {
+    ($scanner:expr, $errval:expr) => {
+        if !$scanner.is_null() && unsafe { &*$scanner }.is_poisoned() {
+            $crate::error::set_last_error(
+                $crate::error::LanceErrorCode::Panic,
+                "scanner is poisoned by an earlier panic",
+            );
+            return $errval;
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
 // Scanner lifecycle + builder
 // ---------------------------------------------------------------------------
 
@@ -296,6 +351,7 @@ unsafe fn scanner_new_inner(
 /// Set the row limit on the scanner. Returns 0.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_set_limit(scanner: *mut LanceScanner, limit: i64) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(unsafe { scanner_set_limit_inner(scanner, limit) }, neg)
 }
 
@@ -313,6 +369,7 @@ unsafe fn scanner_set_limit_inner(scanner: *mut LanceScanner, limit: i64) -> Res
 /// Set the row offset on the scanner. Returns 0.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_set_offset(scanner: *mut LanceScanner, offset: i64) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(unsafe { scanner_set_offset_inner(scanner, offset) }, neg)
 }
 
@@ -333,6 +390,7 @@ pub unsafe extern "C" fn lance_scanner_set_batch_size(
     scanner: *mut LanceScanner,
     batch_size: i64,
 ) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(
         unsafe { scanner_set_batch_size_inner(scanner, batch_size) },
         neg
@@ -356,6 +414,7 @@ pub unsafe extern "C" fn lance_scanner_with_row_id(
     scanner: *mut LanceScanner,
     enable: bool,
 ) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(unsafe { scanner_with_row_id_inner(scanner, enable) }, neg)
 }
 
@@ -380,6 +439,7 @@ pub unsafe extern "C" fn lance_scanner_set_fragment_ids(
     ids: *const u64,
     len: usize,
 ) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(
         unsafe { scanner_set_fragment_ids_inner(scanner, ids, len) },
         neg
@@ -436,6 +496,7 @@ pub unsafe extern "C" fn lance_scanner_set_substrait_filter(
     bytes: *const u8,
     len: usize,
 ) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(
         unsafe { scanner_set_substrait_filter_inner(scanner, bytes, len) },
         neg
@@ -493,6 +554,7 @@ pub unsafe extern "C" fn lance_scanner_to_arrow_stream(
     scanner: *mut LanceScanner,
     out: *mut FFI_ArrowArrayStream,
 ) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(unsafe { scanner_to_arrow_stream_inner(scanner, out) }, neg)
 }
 
@@ -527,6 +589,9 @@ unsafe fn scanner_to_arrow_stream_inner(
 /// - `-1` — error (check `lance_last_error_*`), `*out` is NULL.
 ///
 /// The caller must free each returned batch with `lance_batch_free()`.
+///
+/// A panic in the stream logic poisons the scanner: this call returns -1 with
+/// `LANCE_ERR_PANIC`, and every later call on the handle fails the same way.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_next(
     scanner: *mut LanceScanner,
@@ -539,8 +604,32 @@ pub unsafe extern "C" fn lance_scanner_next(
         );
         return -1;
     }
+    scanner_poison_check!(scanner, -1);
     let s = unsafe { &mut *scanner };
+    let poisoned = s.poison_flag();
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        scanner_next_inner(s, out)
+    })) {
+        Ok(rc) => rc,
+        Err(payload) => {
+            poisoned.store(true, Ordering::SeqCst);
+            set_last_error(
+                LanceErrorCode::Panic,
+                format!("panic in FFI call: {}", panic_payload_message(&*payload)),
+            );
+            unsafe { *out = ptr::null_mut() };
+            -1
+        }
+    }
+}
 
+/// Blocking next-batch logic, split out so `lance_scanner_next` can wrap the
+/// whole thing in `catch_unwind` and poison the handle on panic. Error and
+/// end-of-stream semantics (0/1/-1 plus thread-local error) are unchanged.
+///
+/// # Safety
+/// `out` must be a valid, writable pointer (checked by the caller).
+unsafe fn scanner_next_inner(s: &mut LanceScanner, out: *mut *mut LanceBatch) -> i32 {
     // Lazily materialize the stream on first call.
     if s.stream.is_none()
         && let Err(err) = s.materialize_stream()
@@ -598,6 +687,17 @@ pub unsafe extern "C" fn lance_scanner_scan_async(
     }
 
     let s = unsafe { &*scanner };
+    if s.is_poisoned() {
+        // Hand-rolled poison check (the shared macro cannot dispatch the
+        // error callback this void entry point reports through).
+        set_last_error(
+            LanceErrorCode::Panic,
+            "scanner is poisoned by an earlier panic",
+        );
+        async_dispatcher::dispatch_callback(callback, callback_ctx, -1, ptr::null_mut());
+        return;
+    }
+
     let built_scanner = match s.build_scanner() {
         Ok(sc) => sc,
         Err(err) => {
@@ -662,6 +762,10 @@ pub unsafe extern "C" fn lance_scanner_scan_async(
 ///
 /// The stream is lazily materialized on the first poll call (which will typically
 /// return PENDING while the stream opens).
+///
+/// A panic in the poll logic poisons the scanner: this call returns
+/// `LANCE_POLL_ERROR` with `LANCE_ERR_PANIC`, and every later call on the
+/// handle fails the same way.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_poll_next(
     scanner: *mut LanceScanner,
@@ -676,8 +780,38 @@ pub unsafe extern "C" fn lance_scanner_poll_next(
         );
         return LancePollStatus::Error;
     }
+    scanner_poison_check!(scanner, LancePollStatus::Error);
     let s = unsafe { &mut *scanner };
+    let poisoned = s.poison_flag();
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        scanner_poll_next_inner(s, waker, waker_ctx, out)
+    })) {
+        Ok(status) => status,
+        Err(payload) => {
+            poisoned.store(true, Ordering::SeqCst);
+            set_last_error(
+                LanceErrorCode::Panic,
+                format!("panic in FFI call: {}", panic_payload_message(&*payload)),
+            );
+            unsafe { *out = ptr::null_mut() };
+            LancePollStatus::Error
+        }
+    }
+}
 
+/// Poll logic, split out so `lance_scanner_poll_next` can wrap the whole
+/// thing in `catch_unwind` and poison the handle on panic. Ready/Pending/
+/// Finished/Error mapping and thread-local error semantics are unchanged.
+///
+/// # Safety
+/// `out` must be a valid, writable pointer (checked by the caller);
+/// `waker_ctx` must satisfy the `LanceWaker` contract.
+unsafe fn scanner_poll_next_inner(
+    s: &mut LanceScanner,
+    waker: LanceWaker,
+    waker_ctx: *mut c_void,
+    out: *mut *mut LanceBatch,
+) -> LancePollStatus {
     // Lazily materialize the stream.
     if s.stream.is_none()
         && let Err(err) = s.materialize_stream()
@@ -779,6 +913,7 @@ macro_rules! scanner_set_u32 {
     ($name:ident, $field:ident) => {
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $name(scanner: *mut LanceScanner, value: u32) -> i32 {
+            scanner_poison_check!(scanner, -1);
             ffi_try!(
                 (|| -> Result<i32> {
                     if scanner.is_null() {
@@ -803,6 +938,7 @@ scanner_set_u32!(lance_scanner_set_ef, ef);
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_set_metric(scanner: *mut LanceScanner, metric: i32) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(unsafe { scanner_set_metric_inner(scanner, metric) }, neg)
 }
 
@@ -834,6 +970,7 @@ pub unsafe extern "C" fn lance_scanner_set_use_index(
     scanner: *mut LanceScanner,
     enable: bool,
 ) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(unsafe { scanner_set_use_index_inner(scanner, enable) }, neg)
 }
 
@@ -854,6 +991,7 @@ pub unsafe extern "C" fn lance_scanner_set_prefilter(
     scanner: *mut LanceScanner,
     enable: bool,
 ) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(unsafe { scanner_set_prefilter_inner(scanner, enable) }, neg)
 }
 
@@ -886,6 +1024,7 @@ pub unsafe extern "C" fn lance_scanner_set_index_segments(
     segment_uuids: *const u8,
     len: usize,
 ) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(
         unsafe { scanner_set_index_segments_inner(scanner, segment_uuids, len) },
         neg
@@ -946,6 +1085,7 @@ pub unsafe extern "C" fn lance_scanner_nearest(
     element_type: i32,
     k: u32,
 ) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(
         unsafe { scanner_nearest_inner(scanner, column, query_data, query_len, element_type, k) },
         neg
@@ -1046,6 +1186,7 @@ pub unsafe extern "C" fn lance_scanner_full_text_search(
     columns: *const *const c_char,
     max_fuzzy_distance: u32,
 ) -> i32 {
+    scanner_poison_check!(scanner, -1);
     ffi_try!(
         unsafe { fts_inner(scanner, query, columns, max_fuzzy_distance) },
         neg
@@ -1091,4 +1232,213 @@ unsafe fn fts_inner(
 
     s.fts_query = Some(fts);
     Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataset::{lance_dataset_close, lance_dataset_open};
+    use crate::error::{lance_last_error_code, lance_last_error_message};
+    use std::ffi::{CStr, CString};
+    use std::sync::atomic::AtomicI32;
+
+    use arrow_array::{Int32Array, RecordBatch, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
+
+    /// Write a 3-row dataset to a tempdir, returning (tempdir, uri).
+    fn create_test_dataset() -> (tempfile::TempDir, String) {
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().join("scanner_ds").to_str().unwrap().to_string();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+            ],
+        )
+        .unwrap();
+
+        block_on(Dataset::write(
+            arrow::record_batch::RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &uri,
+            None,
+        ))
+        .unwrap();
+        (tmp, uri)
+    }
+
+    /// Open a dataset + unconfigured scanner through the public entry points.
+    fn open_dataset_and_scanner(uri: &str) -> (*mut LanceDataset, *mut LanceScanner) {
+        let c_uri = CString::new(uri).unwrap();
+        let dataset = unsafe { lance_dataset_open(c_uri.as_ptr(), ptr::null(), 0) };
+        assert!(!dataset.is_null(), "lance_dataset_open failed");
+        let scanner = unsafe { lance_scanner_new(dataset, ptr::null(), ptr::null()) };
+        assert!(!scanner.is_null(), "lance_scanner_new failed");
+        (dataset, scanner)
+    }
+
+    fn poison(scanner: *mut LanceScanner) {
+        unsafe { &*scanner }
+            .poison_flag()
+            .store(true, Ordering::SeqCst);
+    }
+
+    /// Assert the pending thread-local error is `Panic` carrying the poison
+    /// message; consumes it so the next assertion starts from a clean slate.
+    fn assert_poison_error_pending() {
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Panic);
+        let msg_ptr = lance_last_error_message();
+        assert!(!msg_ptr.is_null(), "poison error must carry a message");
+        let msg = unsafe { CStr::from_ptr(msg_ptr) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { crate::error::lance_free_string(msg_ptr) };
+        assert!(
+            msg.contains("poisoned by an earlier panic"),
+            "unexpected message: {msg}"
+        );
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Ok);
+    }
+
+    unsafe extern "C" fn noop_waker(_ctx: *mut c_void) {}
+
+    #[test]
+    fn poisoned_scanner_rejects_setters_with_panic_code() {
+        let (_tmp, uri) = create_test_dataset();
+        let (dataset, scanner) = open_dataset_and_scanner(&uri);
+        poison(scanner);
+
+        // Representative setters across the hand-written and macro-generated
+        // families: each must return -1 with LANCE_ERR_PANIC.
+        let rc = unsafe { lance_scanner_set_limit(scanner, 10) };
+        assert_eq!(rc, -1);
+        assert_poison_error_pending();
+
+        let rc = unsafe { lance_scanner_set_nprobes(scanner, 4) };
+        assert_eq!(rc, -1);
+        assert_poison_error_pending();
+
+        let rc = unsafe { lance_scanner_set_prefilter(scanner, true) };
+        assert_eq!(rc, -1);
+        assert_poison_error_pending();
+
+        // to_arrow_stream also dereferences the handle: same rejection.
+        let mut ffi_stream = FFI_ArrowArrayStream::empty();
+        let rc = unsafe { lance_scanner_to_arrow_stream(scanner, &mut ffi_stream) };
+        assert_eq!(rc, -1);
+        assert_poison_error_pending();
+
+        // Close must still free a poisoned handle (no poison check there).
+        unsafe {
+            lance_scanner_close(scanner);
+            lance_dataset_close(dataset);
+        }
+    }
+
+    #[test]
+    fn poisoned_scanner_next_returns_panic_code() {
+        let (_tmp, uri) = create_test_dataset();
+        let (dataset, scanner) = open_dataset_and_scanner(&uri);
+        poison(scanner);
+
+        let mut batch: *mut LanceBatch = ptr::null_mut();
+        let rc = unsafe { lance_scanner_next(scanner, &mut batch) };
+        assert_eq!(rc, -1);
+        assert!(batch.is_null(), "error path must leave *out NULL");
+        assert_poison_error_pending();
+
+        unsafe {
+            lance_scanner_close(scanner);
+            lance_dataset_close(dataset);
+        }
+    }
+
+    #[test]
+    fn poisoned_scanner_poll_next_returns_error_status() {
+        let (_tmp, uri) = create_test_dataset();
+        let (dataset, scanner) = open_dataset_and_scanner(&uri);
+        poison(scanner);
+
+        let mut batch: *mut LanceBatch = ptr::null_mut();
+        let status =
+            unsafe { lance_scanner_poll_next(scanner, noop_waker, ptr::null_mut(), &mut batch) };
+        assert_eq!(status, LancePollStatus::Error);
+        assert!(batch.is_null(), "error path must leave *out NULL");
+        assert_poison_error_pending();
+
+        unsafe {
+            lance_scanner_close(scanner);
+            lance_dataset_close(dataset);
+        }
+    }
+
+    static CALLBACK_STATUS: AtomicI32 = AtomicI32::new(i32::MIN);
+    static CALLBACK_RESULT_WAS_NULL: AtomicBool = AtomicBool::new(false);
+
+    unsafe extern "C" fn record_status(_ctx: *mut c_void, status: i32, result: *mut c_void) {
+        CALLBACK_STATUS.store(status, Ordering::SeqCst);
+        CALLBACK_RESULT_WAS_NULL.store(result.is_null(), Ordering::SeqCst);
+    }
+
+    #[test]
+    fn poisoned_scanner_scan_async_dispatches_error_callback() {
+        let (_tmp, uri) = create_test_dataset();
+        let (dataset, scanner) = open_dataset_and_scanner(&uri);
+        poison(scanner);
+
+        unsafe { lance_scanner_scan_async(scanner, record_status, ptr::null_mut()) };
+        // The poison error is also visible on the calling thread.
+        assert_poison_error_pending();
+
+        // The void entry point reports through the callback on the dispatcher
+        // thread; wait for delivery.
+        let mut waited_ms = 0;
+        while CALLBACK_STATUS.load(Ordering::SeqCst) == i32::MIN && waited_ms < 5000 {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            waited_ms += 10;
+        }
+        assert_eq!(CALLBACK_STATUS.load(Ordering::SeqCst), -1);
+        assert!(CALLBACK_RESULT_WAS_NULL.load(Ordering::SeqCst));
+
+        unsafe {
+            lance_scanner_close(scanner);
+            lance_dataset_close(dataset);
+        }
+    }
+
+    #[test]
+    fn fresh_scanner_is_not_poisoned() {
+        let (_tmp, uri) = create_test_dataset();
+        let (dataset, scanner) = open_dataset_and_scanner(&uri);
+
+        let rc = unsafe { lance_scanner_set_limit(scanner, 10) };
+        assert_eq!(rc, 0);
+        assert_eq!(lance_last_error_code(), LanceErrorCode::Ok);
+
+        // Smoke-test the newly guarded iteration path end to end.
+        let mut batches = 0;
+        let mut batch: *mut LanceBatch = ptr::null_mut();
+        loop {
+            let rc = unsafe { lance_scanner_next(scanner, &mut batch) };
+            assert!(rc >= 0, "lance_scanner_next failed with {rc}");
+            if rc == 1 {
+                break;
+            }
+            assert!(!batch.is_null());
+            batches += 1;
+            unsafe { crate::lance_batch_free(batch) };
+            batch = ptr::null_mut();
+        }
+        assert!(batches > 0, "dataset must yield at least one batch");
+
+        unsafe {
+            lance_scanner_close(scanner);
+            lance_dataset_close(dataset);
+        }
+    }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -296,27 +296,35 @@ unsafe fn scanner_new_inner(
 /// Set the row limit on the scanner. Returns 0.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_set_limit(scanner: *mut LanceScanner, limit: i64) -> i32 {
+    ffi_try!(unsafe { scanner_set_limit_inner(scanner, limit) }, neg)
+}
+
+unsafe fn scanner_set_limit_inner(scanner: *mut LanceScanner, limit: i64) -> Result<i32> {
     if scanner.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner is NULL".into(),
+        ));
     }
     let s = unsafe { &mut *scanner };
     s.limit = Some(limit);
-    clear_last_error();
-    0
+    Ok(0)
 }
 
 /// Set the row offset on the scanner. Returns 0.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_set_offset(scanner: *mut LanceScanner, offset: i64) -> i32 {
+    ffi_try!(unsafe { scanner_set_offset_inner(scanner, offset) }, neg)
+}
+
+unsafe fn scanner_set_offset_inner(scanner: *mut LanceScanner, offset: i64) -> Result<i32> {
     if scanner.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner is NULL".into(),
+        ));
     }
     let s = unsafe { &mut *scanner };
     s.offset = Some(offset);
-    clear_last_error();
-    0
+    Ok(0)
 }
 
 /// Set the batch size on the scanner. Returns 0.
@@ -325,14 +333,21 @@ pub unsafe extern "C" fn lance_scanner_set_batch_size(
     scanner: *mut LanceScanner,
     batch_size: i64,
 ) -> i32 {
+    ffi_try!(
+        unsafe { scanner_set_batch_size_inner(scanner, batch_size) },
+        neg
+    )
+}
+
+unsafe fn scanner_set_batch_size_inner(scanner: *mut LanceScanner, batch_size: i64) -> Result<i32> {
     if scanner.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner is NULL".into(),
+        ));
     }
     let s = unsafe { &mut *scanner };
     s.batch_size = Some(batch_size as usize);
-    clear_last_error();
-    0
+    Ok(0)
 }
 
 /// Enable or disable row ID in scan output. Returns 0.
@@ -341,14 +356,18 @@ pub unsafe extern "C" fn lance_scanner_with_row_id(
     scanner: *mut LanceScanner,
     enable: bool,
 ) -> i32 {
+    ffi_try!(unsafe { scanner_with_row_id_inner(scanner, enable) }, neg)
+}
+
+unsafe fn scanner_with_row_id_inner(scanner: *mut LanceScanner, enable: bool) -> Result<i32> {
     if scanner.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner is NULL".into(),
+        ));
     }
     let s = unsafe { &mut *scanner };
     s.with_row_id = enable;
-    clear_last_error();
-    0
+    Ok(0)
 }
 
 /// Restrict the scan to the given fragment IDs.
@@ -361,13 +380,26 @@ pub unsafe extern "C" fn lance_scanner_set_fragment_ids(
     ids: *const u64,
     len: usize,
 ) -> i32 {
+    ffi_try!(
+        unsafe { scanner_set_fragment_ids_inner(scanner, ids, len) },
+        neg
+    )
+}
+
+unsafe fn scanner_set_fragment_ids_inner(
+    scanner: *mut LanceScanner,
+    ids: *const u64,
+    len: usize,
+) -> Result<i32> {
     if scanner.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner is NULL".into(),
+        ));
     }
     if ids.is_null() && len > 0 {
-        set_last_error(LanceErrorCode::InvalidArgument, "ids is NULL but len > 0");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "ids is NULL but len > 0".into(),
+        ));
     }
     let s = unsafe { &mut *scanner };
     let id_slice = if len > 0 {
@@ -376,8 +408,7 @@ pub unsafe extern "C" fn lance_scanner_set_fragment_ids(
         &[]
     };
     s.fragment_ids = Some(id_slice.to_vec());
-    clear_last_error();
-    0
+    Ok(0)
 }
 
 /// Set a Substrait filter on the scanner.
@@ -405,26 +436,36 @@ pub unsafe extern "C" fn lance_scanner_set_substrait_filter(
     bytes: *const u8,
     len: usize,
 ) -> i32 {
+    ffi_try!(
+        unsafe { scanner_set_substrait_filter_inner(scanner, bytes, len) },
+        neg
+    )
+}
+
+unsafe fn scanner_set_substrait_filter_inner(
+    scanner: *mut LanceScanner,
+    bytes: *const u8,
+    len: usize,
+) -> Result<i32> {
     if scanner.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner is NULL".into(),
+        ));
     }
     if bytes.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "bytes is NULL");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "bytes is NULL".into(),
+        ));
     }
     if len == 0 {
-        set_last_error(
-            LanceErrorCode::InvalidArgument,
-            "Substrait filter bytes must be non-empty",
-        );
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "Substrait filter bytes must be non-empty".into(),
+        ));
     }
     let slice = unsafe { std::slice::from_raw_parts(bytes, len) };
     let s = unsafe { &mut *scanner };
     s.substrait_filter = Some(slice.to_vec());
-    clear_last_error();
-    0
+    Ok(0)
 }
 
 /// Close and free a scanner handle.
@@ -738,15 +779,20 @@ macro_rules! scanner_set_u32 {
     ($name:ident, $field:ident) => {
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $name(scanner: *mut LanceScanner, value: u32) -> i32 {
-            if scanner.is_null() {
-                set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-                return -1;
-            }
-            unsafe {
-                (*scanner).$field = Some(value);
-            }
-            crate::error::clear_last_error();
-            0
+            ffi_try!(
+                (|| -> Result<i32> {
+                    if scanner.is_null() {
+                        return Err(lance_core::Error::invalid_input_source(
+                            "scanner is NULL".into(),
+                        ));
+                    }
+                    unsafe {
+                        (*scanner).$field = Some(value);
+                    }
+                    Ok(0)
+                })(),
+                neg
+            )
         }
     };
 }
@@ -757,9 +803,14 @@ scanner_set_u32!(lance_scanner_set_ef, ef);
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_scanner_set_metric(scanner: *mut LanceScanner, metric: i32) -> i32 {
+    ffi_try!(unsafe { scanner_set_metric_inner(scanner, metric) }, neg)
+}
+
+unsafe fn scanner_set_metric_inner(scanner: *mut LanceScanner, metric: i32) -> Result<i32> {
     if scanner.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner is NULL".into(),
+        ));
     }
     let m = match metric {
         0 => crate::index::LanceMetricType::L2,
@@ -767,18 +818,15 @@ pub unsafe extern "C" fn lance_scanner_set_metric(scanner: *mut LanceScanner, me
         2 => crate::index::LanceMetricType::Dot,
         3 => crate::index::LanceMetricType::Hamming,
         _ => {
-            set_last_error(
-                LanceErrorCode::InvalidArgument,
-                format!("invalid metric: {}", metric),
-            );
-            return -1;
+            return Err(lance_core::Error::invalid_input_source(
+                format!("invalid metric: {}", metric).into(),
+            ));
         }
     };
     unsafe {
         (*scanner).metric_override = Some(m);
     }
-    crate::error::clear_last_error();
-    0
+    Ok(0)
 }
 
 #[unsafe(no_mangle)]
@@ -786,15 +834,19 @@ pub unsafe extern "C" fn lance_scanner_set_use_index(
     scanner: *mut LanceScanner,
     enable: bool,
 ) -> i32 {
+    ffi_try!(unsafe { scanner_set_use_index_inner(scanner, enable) }, neg)
+}
+
+unsafe fn scanner_set_use_index_inner(scanner: *mut LanceScanner, enable: bool) -> Result<i32> {
     if scanner.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner is NULL".into(),
+        ));
     }
     unsafe {
         (*scanner).use_index = Some(enable);
     }
-    crate::error::clear_last_error();
-    0
+    Ok(0)
 }
 
 #[unsafe(no_mangle)]
@@ -802,15 +854,19 @@ pub unsafe extern "C" fn lance_scanner_set_prefilter(
     scanner: *mut LanceScanner,
     enable: bool,
 ) -> i32 {
+    ffi_try!(unsafe { scanner_set_prefilter_inner(scanner, enable) }, neg)
+}
+
+unsafe fn scanner_set_prefilter_inner(scanner: *mut LanceScanner, enable: bool) -> Result<i32> {
     if scanner.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner is NULL".into(),
+        ));
     }
     unsafe {
         (*scanner).prefilter = enable;
     }
-    crate::error::clear_last_error();
-    0
+    Ok(0)
 }
 
 /// Restrict the next `nearest()` query to a specific subset of vector index segments.
@@ -830,16 +886,26 @@ pub unsafe extern "C" fn lance_scanner_set_index_segments(
     segment_uuids: *const u8,
     len: usize,
 ) -> i32 {
+    ffi_try!(
+        unsafe { scanner_set_index_segments_inner(scanner, segment_uuids, len) },
+        neg
+    )
+}
+
+unsafe fn scanner_set_index_segments_inner(
+    scanner: *mut LanceScanner,
+    segment_uuids: *const u8,
+    len: usize,
+) -> Result<i32> {
     if scanner.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "scanner is NULL");
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "scanner is NULL".into(),
+        ));
     }
     if segment_uuids.is_null() && len > 0 {
-        set_last_error(
-            LanceErrorCode::InvalidArgument,
-            "segment_uuids is NULL but len > 0",
-        );
-        return -1;
+        return Err(lance_core::Error::invalid_input_source(
+            "segment_uuids is NULL but len > 0".into(),
+        ));
     }
     let s = unsafe { &mut *scanner };
     if len == 0 {
@@ -855,8 +921,7 @@ pub unsafe extern "C" fn lance_scanner_set_index_segments(
         }
         s.index_segments = Some(uuids);
     }
-    crate::error::clear_last_error();
-    0
+    Ok(0)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/stream_guard.rs
+++ b/src/stream_guard.rs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Panic guard for exported Arrow streams (issue #61).
+//!
+//! An exported `FFI_ArrowArrayStream` outlives the call that created it:
+//! lance-io's `RecordBatchIteratorAdaptor::next()` runs
+//! `handle.block_on(stream.next())` inside the *consumer's* later `get_next`
+//! call, on the consumer's thread, and neither arrow-rs nor lance-io guards
+//! that call. A mid-iteration panic therefore unwinds out of arrow-rs's
+//! `extern "C" fn get_next` and aborts the host process even under
+//! `panic = "unwind"` (Rust 1.81+ semantics). Catching the panic inside the
+//! stream's own `poll_next` is the only placement that covers every
+//! consumer-thread poll, which is what [`GuardedStream`] does.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
+
+use arrow_array::RecordBatch;
+use futures::Stream;
+
+use crate::error::panic_payload_message;
+
+/// A stream wrapper that catches a panic from the inner stream's `poll_next`
+/// and converts it into the Arrow C stream error contract: exactly one
+/// terminal `Some(Err(..))` item — which arrow-rs's exported `get_next` maps
+/// to a nonzero return plus `get_last_error` — followed by end-of-stream
+/// (`None`) on every later poll. C consumers therefore observe an ordinary
+/// stream error instead of a process abort, with no consumer-side changes.
+///
+/// On a caught panic the wrapper also flips `scanner_poison`, the flag shared
+/// with the owning `LanceScanner` handle (see `LanceScanner::poison_flag()`),
+/// so every later `lance_scanner_*` call on that handle fails with
+/// `LANCE_ERR_PANIC` instead of touching possibly-wedged stream state.
+///
+/// The panic message is sanitized by [`panic_payload_message`] (NUL bytes
+/// replaced) before it is baked into the error string: arrow-rs's `get_next`
+/// runs `CString::new` on this string, and an embedded NUL would panic right
+/// through the guard.
+///
+/// Upstream note: this wrapper is a candidate for promotion into
+/// `lance_io::ffi::to_ffi_arrow_array_stream` itself, which would extend the
+/// same protection to every consumer of that export path (e.g. lance-java).
+pub struct GuardedStream<S> {
+    inner: S,
+    /// Fused state: set when a panic is caught, after which every poll
+    /// yields `None` (end-of-stream) without touching the inner stream again.
+    poisoned: bool,
+    /// Shared with the owning scanner handle; flipped when a panic is caught
+    /// so the handle rejects later calls with `LANCE_ERR_PANIC`.
+    scanner_poison: Arc<AtomicBool>,
+}
+
+impl<S> GuardedStream<S> {
+    /// Wrap `inner`, wiring the shared `scanner_poison` flag that a caught
+    /// panic sets (from `LanceScanner::poison_flag()` at the export sites).
+    pub fn new(inner: S, scanner_poison: Arc<AtomicBool>) -> Self {
+        Self {
+            inner,
+            poisoned: false,
+            scanner_poison,
+        }
+    }
+}
+
+impl<S> Stream for GuardedStream<S>
+where
+    S: Stream<Item = lance_core::Result<RecordBatch>> + Unpin,
+{
+    type Item = lance_core::Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.poisoned {
+            return Poll::Ready(None);
+        }
+        let this = &mut *self;
+        let polled = catch_unwind(AssertUnwindSafe(|| Pin::new(&mut this.inner).poll_next(cx)));
+        match polled {
+            Ok(item) => item,
+            Err(payload) => {
+                this.poisoned = true;
+                this.scanner_poison.store(true, Ordering::SeqCst);
+                Poll::Ready(Some(Err(lance_core::Error::internal(format!(
+                    "panic in stream: {}",
+                    panic_payload_message(&*payload)
+                )))))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::Int32Array;
+    use arrow_schema::{DataType, Field, Schema};
+    use futures::StreamExt;
+
+    use crate::runtime::block_on;
+
+    fn test_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+        RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))]).unwrap()
+    }
+
+    /// A stream that yields one batch, then panics with `message` —
+    /// simulating an unwrap/index bug deep in Lance or Arrow scan code. (The
+    /// panic hook prints to stderr during these tests; that is expected
+    /// noise.)
+    struct PanicOnSecondPoll {
+        yielded: bool,
+        message: &'static str,
+    }
+
+    impl Stream for PanicOnSecondPoll {
+        type Item = lance_core::Result<RecordBatch>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            if !self.yielded {
+                self.yielded = true;
+                Poll::Ready(Some(Ok(test_batch())))
+            } else {
+                panic!("{}", self.message)
+            }
+        }
+    }
+
+    #[test]
+    fn panic_yields_one_error_then_fuses_and_flips_flag() {
+        let scanner_poison = Arc::new(AtomicBool::new(false));
+        let mut stream = GuardedStream::new(
+            PanicOnSecondPoll {
+                yielded: false,
+                message: "simulated scan bug",
+            },
+            Arc::clone(&scanner_poison),
+        );
+
+        // The pre-panic item passes through untouched.
+        let item = block_on(stream.next()).expect("stream ended before first batch");
+        let batch = item.expect("first batch must pass through as Ok");
+        assert_eq!(batch.num_rows(), 3);
+
+        // The panic becomes exactly one terminal Err item carrying the
+        // sanitized payload, and the shared flag flips.
+        let item = block_on(stream.next()).expect("panic item missing");
+        let err = item.expect_err("panic must surface as an Err item");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("simulated scan bug"),
+            "panic payload must reach the error message, got: {msg}"
+        );
+        assert!(
+            !msg.contains('\0'),
+            "error string must be NUL-free, got: {msg:?}"
+        );
+        assert!(
+            scanner_poison.load(Ordering::SeqCst),
+            "scanner poison flag must flip on panic"
+        );
+
+        // Then the stream is fused: None forever, no repeat panic, no second
+        // error item.
+        assert!(
+            block_on(stream.next()).is_none(),
+            "fused stream must yield None"
+        );
+        assert!(
+            block_on(stream.next()).is_none(),
+            "fused stream must stay fused"
+        );
+    }
+
+    #[test]
+    fn panic_payload_with_nul_is_sanitized() {
+        let scanner_poison = Arc::new(AtomicBool::new(false));
+        let mut stream = GuardedStream::new(
+            PanicOnSecondPoll {
+                yielded: false,
+                message: "bo\0om",
+            },
+            scanner_poison,
+        );
+
+        let _ = block_on(stream.next()); // consume the good batch
+        let err = block_on(stream.next())
+            .expect("panic item missing")
+            .expect_err("panic must surface as an Err item");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains('\0'),
+            "embedded NUL must be sanitized, got: {msg:?}"
+        );
+        assert!(
+            msg.contains("bo\\0om"),
+            "NUL must render as the 2-char escape, got: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn no_panic_passes_items_through_and_flag_stays_clear() {
+        let scanner_poison = Arc::new(AtomicBool::new(false));
+        let inner = futures::stream::iter(vec![Ok(test_batch()), Ok(test_batch())]);
+        let mut stream = GuardedStream::new(inner, Arc::clone(&scanner_poison));
+
+        for i in 0..2 {
+            let item = block_on(stream.next()).expect("stream ended early");
+            let batch = item.expect("batch must pass through untouched");
+            assert_eq!(batch.num_rows(), 3, "batch {i} contents changed");
+        }
+        assert!(
+            block_on(stream.next()).is_none(),
+            "inner end-of-stream must pass through"
+        );
+        assert!(
+            !scanner_poison.load(Ordering::SeqCst),
+            "flag must stay false without a panic"
+        );
+    }
+}

--- a/src/stream_guard.rs
+++ b/src/stream_guard.rs
@@ -3,50 +3,66 @@
 
 //! Panic guard for exported Arrow streams (issue #61).
 //!
-//! An exported `FFI_ArrowArrayStream` outlives the call that created it:
-//! lance-io's `RecordBatchIteratorAdaptor::next()` runs
-//! `handle.block_on(stream.next())` inside the *consumer's* later `get_next`
-//! call, on the consumer's thread, and neither arrow-rs nor lance-io guards
-//! that call. A mid-iteration panic therefore unwinds out of arrow-rs's
-//! `extern "C" fn get_next` and aborts the host process even under
-//! `panic = "unwind"` (Rust 1.81+ semantics). Catching the panic inside the
-//! stream's own `poll_next` is the only placement that covers every
-//! consumer-thread poll, which is what [`GuardedStream`] does.
+//! An exported `FFI_ArrowArrayStream` outlives the call that created it: the
+//! consumer's later `get_next` / `release` calls re-enter our code on the
+//! *consumer's* thread, through arrow-rs's `extern "C"` callbacks, and
+//! neither arrow-rs nor lance-io guards those calls. The guard therefore
+//! sits at the outermost Rust edge the C consumer can reach — the
+//! [`RecordBatchReader`] that arrow-rs's callbacks invoke — not inside the
+//! stream:
+//!
+//! - **`get_next` → `Iterator::next`**: the catch wraps the *complete*
+//!   `handle.block_on(stream.next())` operation. Catching inside the
+//!   stream's `poll_next` would be too late: `Handle::block_on` itself
+//!   panics before any poll when the consumer's thread is currently driving
+//!   a Tokio runtime ("Cannot start a runtime from within a runtime"), and
+//!   that panic would unwind out of arrow-rs's `extern "C" fn get_next` and
+//!   abort the host. A caught panic becomes exactly one terminal
+//!   `Some(Err(..))` item — which arrow-rs's exported `get_next` maps to a
+//!   nonzero return plus `get_last_error` — followed by end-of-stream, and
+//!   flips the shared `scanner_poison` flag so the owning scanner handle
+//!   rejects later calls with `LANCE_ERR_PANIC`.
+//!
+//! - **`release` → `Drop`**: arrow-rs's `release_stream` drops this reader
+//!   (and with it the inner Lance stream) inside its `extern "C"` callback,
+//!   so [`GuardedReader::drop`] detaches the inner stream and drops it under
+//!   `catch_unwind`, accepting a leak of the remainder per the documented
+//!   best-effort close/free policy in `lance.h`. A cleanup panic is logged,
+//!   not poisoned — the handle's own state was never touched.
+//!
+//! The panic message is sanitized by [`panic_payload_message`] (NUL bytes
+//! replaced) before it is baked into the error string: arrow-rs's `get_next`
+//! runs `CString::new` on this string, and an embedded NUL would panic right
+//! through the guard.
+//!
+//! Upstream note: this reader is a candidate for promotion into
+//! `lance_io::ffi::to_ffi_arrow_array_stream` itself, which would extend the
+//! same protection to every consumer of that export path (e.g. lance-java).
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::task::{Context, Poll};
 
+use arrow::record_batch::RecordBatchReader;
 use arrow_array::RecordBatch;
-use futures::Stream;
+use arrow_schema::{ArrowError, SchemaRef};
+use futures::{Stream, StreamExt};
 
-use crate::error::panic_payload_message;
+use crate::error::{panic_payload_message, swallow_unwind};
 
-/// A stream wrapper that catches a panic from the inner stream's `poll_next`
-/// and converts it into the Arrow C stream error contract: exactly one
-/// terminal `Some(Err(..))` item — which arrow-rs's exported `get_next` maps
-/// to a nonzero return plus `get_last_error` — followed by end-of-stream
-/// (`None`) on every later poll. C consumers therefore observe an ordinary
-/// stream error instead of a process abort, with no consumer-side changes.
-///
-/// On a caught panic the wrapper also flips `scanner_poison`, the flag shared
-/// with the owning `LanceScanner` handle (see `LanceScanner::poison_flag()`),
-/// so every later `lance_scanner_*` call on that handle fails with
-/// `LANCE_ERR_PANIC` instead of touching possibly-wedged stream state.
-///
-/// The panic message is sanitized by [`panic_payload_message`] (NUL bytes
-/// replaced) before it is baked into the error string: arrow-rs's `get_next`
-/// runs `CString::new` on this string, and an embedded NUL would panic right
-/// through the guard.
-///
-/// Upstream note: this wrapper is a candidate for promotion into
-/// `lance_io::ffi::to_ffi_arrow_array_stream` itself, which would extend the
-/// same protection to every consumer of that export path (e.g. lance-java).
-pub struct GuardedStream<S> {
-    inner: S,
-    /// Fused state: set when a panic is caught, after which every poll
+/// A [`RecordBatchReader`] that owns the exported Lance stream, drives it
+/// with a Tokio runtime handle, and contains panics at both C-reachable
+/// edges (`next` and `drop`) — see the module docs for why the guard lives
+/// at this level. Construct via [`GuardedReader::new`] and export with
+/// `FFI_ArrowArrayStream::new(Box::new(reader))`.
+pub struct GuardedReader<S> {
+    /// An `Option` solely so [`GuardedReader::drop`] can detach ownership
+    /// before running cleanup under `catch_unwind`; always `Some` outside
+    /// the destructor.
+    inner: Option<S>,
+    schema: SchemaRef,
+    handle: tokio::runtime::Handle,
+    /// Fused state: set when a panic is caught, after which every `next`
     /// yields `None` (end-of-stream) without touching the inner stream again.
     poisoned: bool,
     /// Shared with the owning scanner handle; flipped when a panic is caught
@@ -54,41 +70,91 @@ pub struct GuardedStream<S> {
     scanner_poison: Arc<AtomicBool>,
 }
 
-impl<S> GuardedStream<S> {
-    /// Wrap `inner`, wiring the shared `scanner_poison` flag that a caught
-    /// panic sets (from `LanceScanner::poison_flag()` at the export sites).
-    pub fn new(inner: S, scanner_poison: Arc<AtomicBool>) -> Self {
+impl<S> GuardedReader<S> {
+    /// Wrap `inner`, driving it with `handle` and wiring the shared
+    /// `scanner_poison` flag that a caught panic sets (from
+    /// `LanceScanner::poison_flag()` at the export sites).
+    pub fn new(
+        inner: S,
+        schema: SchemaRef,
+        handle: tokio::runtime::Handle,
+        scanner_poison: Arc<AtomicBool>,
+    ) -> Self {
         Self {
-            inner,
+            inner: Some(inner),
+            schema,
+            handle,
             poisoned: false,
             scanner_poison,
         }
     }
 }
 
-impl<S> Stream for GuardedStream<S>
+impl<S> Iterator for GuardedReader<S>
 where
     S: Stream<Item = lance_core::Result<RecordBatch>> + Unpin,
 {
-    type Item = lance_core::Result<RecordBatch>;
+    type Item = std::result::Result<RecordBatch, ArrowError>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn next(&mut self) -> Option<Self::Item> {
         if self.poisoned {
-            return Poll::Ready(None);
+            return None;
         }
-        let this = &mut *self;
-        let polled = catch_unwind(AssertUnwindSafe(|| Pin::new(&mut this.inner).poll_next(cx)));
+        let Self {
+            inner,
+            handle,
+            poisoned,
+            scanner_poison,
+            ..
+        } = self;
+        // `None` only while `Drop` is running, when `next` can no longer be
+        // called; arrow-rs never invokes `get_next` after `release`.
+        let inner = inner.as_mut()?;
+        // The catch covers the WHOLE block_on + poll operation: a panic in
+        // `Handle::block_on` (runtime-driving consumer thread) or in the
+        // stream's `poll_next` lands here, one frame below arrow-rs's
+        // `extern "C"` callback, so neither can unwind across the FFI
+        // boundary.
+        let polled = catch_unwind(AssertUnwindSafe(|| handle.block_on(inner.next())));
         match polled {
-            Ok(item) => item,
+            Ok(Some(Ok(batch))) => Some(Ok(batch)),
+            Ok(Some(Err(err))) => Some(Err(ArrowError::ExternalError(Box::new(err)))),
+            Ok(None) => None,
             Err(payload) => {
-                this.poisoned = true;
-                this.scanner_poison.store(true, Ordering::SeqCst);
-                Poll::Ready(Some(Err(lance_core::Error::internal(format!(
-                    "panic in stream: {}",
-                    panic_payload_message(&*payload)
-                )))))
+                *poisoned = true;
+                scanner_poison.store(true, Ordering::SeqCst);
+                Some(Err(ArrowError::ExternalError(Box::new(
+                    lance_core::Error::internal(format!(
+                        "panic in stream: {}",
+                        panic_payload_message(&*payload)
+                    )),
+                ))))
             }
         }
+    }
+}
+
+impl<S> RecordBatchReader for GuardedReader<S>
+where
+    S: Stream<Item = lance_core::Result<RecordBatch>> + Unpin + Send,
+{
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+impl<S> Drop for GuardedReader<S> {
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.take() else {
+            return;
+        };
+        // arrow-rs's `release_stream` runs this drop inside its `extern "C"`
+        // callback: a panic unwinding out of here would abort the host
+        // process. Ownership was detached above, so a contained cleanup panic
+        // can only leak the remainder — the documented best-effort policy.
+        swallow_unwind("GuardedReader::drop (ArrowArrayStream release)", || {
+            drop(inner)
+        });
     }
 }
 
@@ -97,13 +163,19 @@ mod tests {
     use super::*;
     use arrow_array::Int32Array;
     use arrow_schema::{DataType, Field, Schema};
-    use futures::StreamExt;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
 
-    use crate::runtime::block_on;
+    fn test_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]))
+    }
 
     fn test_batch() -> RecordBatch {
-        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
-        RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))]).unwrap()
+        RecordBatch::try_new(
+            test_schema(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap()
     }
 
     /// A stream that yields one batch, then panics with `message` —
@@ -128,10 +200,22 @@ mod tests {
         }
     }
 
+    fn reader_for<S>(
+        stream: S,
+        scanner_poison: Arc<AtomicBool>,
+    ) -> (tokio::runtime::Runtime, GuardedReader<S>)
+    where
+        S: Stream<Item = lance_core::Result<RecordBatch>> + Unpin,
+    {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let reader = GuardedReader::new(stream, test_schema(), rt.handle().clone(), scanner_poison);
+        (rt, reader)
+    }
+
     #[test]
     fn panic_yields_one_error_then_fuses_and_flips_flag() {
         let scanner_poison = Arc::new(AtomicBool::new(false));
-        let mut stream = GuardedStream::new(
+        let (_rt, mut reader) = reader_for(
             PanicOnSecondPoll {
                 yielded: false,
                 message: "simulated scan bug",
@@ -140,14 +224,18 @@ mod tests {
         );
 
         // The pre-panic item passes through untouched.
-        let item = block_on(stream.next()).expect("stream ended before first batch");
-        let batch = item.expect("first batch must pass through as Ok");
+        let batch = reader
+            .next()
+            .expect("stream ended before first batch")
+            .expect("first batch must pass through as Ok");
         assert_eq!(batch.num_rows(), 3);
 
         // The panic becomes exactly one terminal Err item carrying the
         // sanitized payload, and the shared flag flips.
-        let item = block_on(stream.next()).expect("panic item missing");
-        let err = item.expect_err("panic must surface as an Err item");
+        let err = reader
+            .next()
+            .expect("panic item missing")
+            .expect_err("panic must surface as an Err item");
         let msg = err.to_string();
         assert!(
             msg.contains("simulated scan bug"),
@@ -162,22 +250,16 @@ mod tests {
             "scanner poison flag must flip on panic"
         );
 
-        // Then the stream is fused: None forever, no repeat panic, no second
+        // Then the reader is fused: None forever, no repeat panic, no second
         // error item.
-        assert!(
-            block_on(stream.next()).is_none(),
-            "fused stream must yield None"
-        );
-        assert!(
-            block_on(stream.next()).is_none(),
-            "fused stream must stay fused"
-        );
+        assert!(reader.next().is_none(), "fused reader must yield None");
+        assert!(reader.next().is_none(), "fused reader must stay fused");
     }
 
     #[test]
     fn panic_payload_with_nul_is_sanitized() {
         let scanner_poison = Arc::new(AtomicBool::new(false));
-        let mut stream = GuardedStream::new(
+        let (_rt, mut reader) = reader_for(
             PanicOnSecondPoll {
                 yielded: false,
                 message: "bo\0om",
@@ -185,8 +267,9 @@ mod tests {
             scanner_poison,
         );
 
-        let _ = block_on(stream.next()); // consume the good batch
-        let err = block_on(stream.next())
+        let _ = reader.next(); // consume the good batch
+        let err = reader
+            .next()
             .expect("panic item missing")
             .expect_err("panic must surface as an Err item");
         let msg = err.to_string();
@@ -204,20 +287,98 @@ mod tests {
     fn no_panic_passes_items_through_and_flag_stays_clear() {
         let scanner_poison = Arc::new(AtomicBool::new(false));
         let inner = futures::stream::iter(vec![Ok(test_batch()), Ok(test_batch())]);
-        let mut stream = GuardedStream::new(inner, Arc::clone(&scanner_poison));
+        let (_rt, mut reader) = reader_for(inner, Arc::clone(&scanner_poison));
 
         for i in 0..2 {
-            let item = block_on(stream.next()).expect("stream ended early");
-            let batch = item.expect("batch must pass through untouched");
+            let batch = reader
+                .next()
+                .expect("stream ended early")
+                .expect("batch must pass through untouched");
             assert_eq!(batch.num_rows(), 3, "batch {i} contents changed");
         }
         assert!(
-            block_on(stream.next()).is_none(),
+            reader.next().is_none(),
             "inner end-of-stream must pass through"
         );
         assert!(
             !scanner_poison.load(Ordering::SeqCst),
             "flag must stay false without a panic"
+        );
+    }
+
+    /// Regression for the review finding that a stream-level guard catches
+    /// too late: `Handle::block_on` panics *before any poll* when the calling
+    /// thread is currently driving a Tokio runtime (inside `Runtime::block_on`
+    /// or a spawned task — a merely `enter()`ed context does not trip tokio's
+    /// check). The reader-level catch must turn that into the same
+    /// terminal-error + fuse + poison contract instead of letting it unwind
+    /// out of arrow-rs's `extern "C" fn get_next`.
+    #[test]
+    fn block_on_panic_on_runtime_driving_thread_is_contained() {
+        let scanner_poison = Arc::new(AtomicBool::new(false));
+        let (rt, mut reader) = reader_for(
+            PanicOnSecondPoll {
+                yielded: false,
+                message: "unreachable: block_on panics before any poll",
+            },
+            Arc::clone(&scanner_poison),
+        );
+
+        // Drive `next` from inside a future running ON the runtime: this is
+        // the consumer context in which tokio's `Handle::block_on` panics.
+        let reader_ref = &mut reader;
+        let err = rt
+            .block_on(async move { reader_ref.next() })
+            .expect("panic item missing")
+            .expect_err("block_on panic must surface as an Err item");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("runtime"),
+            "expected tokio's runtime-driving panic message, got: {msg}"
+        );
+        assert!(
+            scanner_poison.load(Ordering::SeqCst),
+            "scanner poison flag must flip on a block_on panic"
+        );
+        // Back outside the runtime context the guard stays fused without
+        // touching the inner stream (or block_on) again.
+        assert!(reader.next().is_none(), "guard must fuse after the panic");
+    }
+
+    /// A stream whose cleanup panics — simulating a wedged Lance/Arrow
+    /// destructor on the `release` path.
+    struct PanicOnDrop;
+
+    impl Stream for PanicOnDrop {
+        type Item = lance_core::Result<RecordBatch>;
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(None)
+        }
+    }
+
+    impl Drop for PanicOnDrop {
+        fn drop(&mut self) {
+            panic!("simulated drop bug in stream cleanup");
+        }
+    }
+
+    /// Regression for the review finding that the release path was unguarded:
+    /// arrow-rs's `release_stream` drops this reader inside its `extern "C"`
+    /// callback, so a cleanup panic must be contained here (best-effort:
+    /// logged, remainder leaked) rather than unwinding out and aborting the
+    /// host. Cleanup failure does not poison the scanner handle.
+    #[test]
+    fn drop_panic_is_contained_without_poisoning() {
+        let scanner_poison = Arc::new(AtomicBool::new(false));
+        let (_rt, reader) = reader_for(PanicOnDrop, Arc::clone(&scanner_poison));
+
+        // Must not unwind out: if it did, this test process would abort.
+        drop(reader);
+
+        assert!(
+            !scanner_poison.load(Ordering::SeqCst),
+            "cleanup panic is best-effort and must not poison the handle"
         );
     }
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -9,7 +9,7 @@
 use lance_core::Result;
 
 use crate::dataset::LanceDataset;
-use crate::error::{LanceErrorCode, clear_last_error, ffi_try, set_last_error};
+use crate::error::ffi_try;
 use crate::runtime::block_on;
 
 /// Opaque snapshot of a dataset's version history.
@@ -53,22 +53,28 @@ unsafe fn versions_inner(dataset: *const LanceDataset) -> Result<*mut LanceVersi
 /// Return the number of versions. Returns 0 on error (NULL handle).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_versions_count(versions: *const LanceVersions) -> u64 {
+    ffi_try!(unsafe { count_inner(versions) }, 0)
+}
+
+unsafe fn count_inner(versions: *const LanceVersions) -> Result<u64> {
     if versions.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "versions is NULL");
-        return 0;
+        return Err(lance_core::Error::invalid_input_source(
+            "versions is NULL".into(),
+        ));
     }
     let v = unsafe { &*versions };
-    clear_last_error();
-    v.entries.len() as u64
+    Ok(v.entries.len() as u64)
 }
 
 /// Return the monotonic version id at `index` (0 <= index < count).
 /// Returns 0 and sets the thread-local error on NULL or out-of-range input.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_versions_id_at(versions: *const LanceVersions, index: usize) -> u64 {
-    unsafe { entry_at(versions, index) }
-        .map(|e| e.id)
-        .unwrap_or(0)
+    ffi_try!(unsafe { id_at_inner(versions, index) }, 0)
+}
+
+unsafe fn id_at_inner(versions: *const LanceVersions, index: usize) -> Result<u64> {
+    Ok(unsafe { entry_at(versions, index) }?.id)
 }
 
 /// Return the Unix epoch millisecond timestamp at `index`.
@@ -78,9 +84,11 @@ pub unsafe extern "C" fn lance_versions_timestamp_ms_at(
     versions: *const LanceVersions,
     index: usize,
 ) -> i64 {
-    unsafe { entry_at(versions, index) }
-        .map(|e| e.timestamp_ms)
-        .unwrap_or(0)
+    ffi_try!(unsafe { timestamp_ms_at_inner(versions, index) }, 0)
+}
+
+unsafe fn timestamp_ms_at_inner(versions: *const LanceVersions, index: usize) -> Result<i64> {
+    Ok(unsafe { entry_at(versions, index) }?.timestamp_ms)
 }
 
 /// Close and free a versions handle. Safe to call with NULL.
@@ -97,29 +105,23 @@ pub unsafe extern "C" fn lance_versions_close(versions: *mut LanceVersions) {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/// Copy the entry at `index` out of the versions handle. Sets the thread-local
-/// error and returns `None` on NULL handle or out-of-range index.
-unsafe fn entry_at(versions: *const LanceVersions, index: usize) -> Option<VersionEntry> {
+/// Copy the entry at `index` out of the versions handle. Returns an
+/// `InvalidArgument` error on NULL handle or out-of-range index.
+unsafe fn entry_at(versions: *const LanceVersions, index: usize) -> Result<VersionEntry> {
     if versions.is_null() {
-        set_last_error(LanceErrorCode::InvalidArgument, "versions is NULL");
-        return None;
+        return Err(lance_core::Error::invalid_input_source(
+            "versions is NULL".into(),
+        ));
     }
     let v = unsafe { &*versions };
-    match v.entries.get(index).copied() {
-        Some(e) => {
-            clear_last_error();
-            Some(e)
-        }
-        None => {
-            set_last_error(
-                LanceErrorCode::InvalidArgument,
-                format!(
-                    "version index {} out of range; count = {}",
-                    index,
-                    v.entries.len()
-                ),
-            );
-            None
-        }
-    }
+    v.entries.get(index).copied().ok_or_else(|| {
+        lance_core::Error::invalid_input_source(
+            format!(
+                "version index {} out of range; count = {}",
+                index,
+                v.entries.len()
+            )
+            .into(),
+        )
+    })
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -9,7 +9,7 @@
 use lance_core::Result;
 
 use crate::dataset::LanceDataset;
-use crate::error::ffi_try;
+use crate::error::{ffi_try, swallow_unwind};
 use crate::runtime::block_on;
 
 /// Opaque snapshot of a dataset's version history.
@@ -92,12 +92,16 @@ unsafe fn timestamp_ms_at_inner(versions: *const LanceVersions, index: usize) ->
 }
 
 /// Close and free a versions handle. Safe to call with NULL.
+///
+/// Best-effort (issue #61): a panic raised while dropping the handle is
+/// caught and logged rather than unwinding into the caller, and the
+/// remainder of the value may leak.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lance_versions_close(versions: *mut LanceVersions) {
     if !versions.is_null() {
-        unsafe {
+        swallow_unwind("lance_versions_close", || unsafe {
             let _ = Box::from_raw(versions);
-        }
+        });
     }
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -132,17 +132,25 @@ pub unsafe extern "C" fn lance_dataset_write(
     storage_opts: *const *const c_char,
     out_dataset: *mut *mut LanceDataset,
 ) -> i32 {
-    unsafe {
-        lance_dataset_write_with_params(
-            uri,
-            schema,
-            stream,
-            mode,
-            std::ptr::null(),
-            storage_opts,
-            out_dataset,
-        )
-    }
+    // Wrap the shared inner fn directly rather than forwarding to the
+    // `lance_dataset_write_with_params` extern: both extern "C" frames must
+    // carry their own panic guard, and a guard around the forwarding call
+    // would clear the thread-local error the inner guard just set (its
+    // `-1` return looks like `Ok(-1)` to an outer guard).
+    ffi_try!(
+        unsafe {
+            write_dataset_inner(
+                uri,
+                schema,
+                stream,
+                mode,
+                std::ptr::null(),
+                storage_opts,
+                out_dataset,
+            )
+        },
+        neg
+    )
 }
 
 /// Same as `lance_dataset_write` but takes a `LanceWriteParams` for tuning the

--- a/tests/panic_stream_guard.rs
+++ b/tests/panic_stream_guard.rs
@@ -3,10 +3,13 @@
 
 //! Regression tests for issue #61 (panic handling across the FFI boundary).
 //!
-//! Both tests drive the *exact* mechanism a C consumer hits when reading a
-//! `lance_scanner_to_arrow_stream` export (lance-io's
-//! `RecordBatchIteratorAdaptor::next()` runs `handle.block_on(stream.next())`
-//! inside the consumer's `get_next` call):
+//! All tests drive the *exact* mechanism a C consumer hits when reading an
+//! exported `ArrowArrayStream`: through the raw `get_next` / `release`
+//! function pointers, not through any Rust wrapper. The shipped guard is
+//! `lance_c::stream_guard::GuardedReader`, wired into both scanner export
+//! sites in `src/scanner.rs`; it drives the stream with
+//! `handle.block_on(stream.next())` inside the consumer's `get_next` call,
+//! exactly like lance-io's unguarded `RecordBatchIteratorAdaptor` does.
 //!
 //! 1. `unguarded_stream_panic_aborts_process` — an unguarded stream that
 //!    panics mid-iteration kills the host process even under
@@ -16,13 +19,27 @@
 //!    exports a raw panicking stream — the mechanism must stay so the test
 //!    keeps proving the gap is real.
 //!
-//! 2. `guarded_stream_maps_panic_to_c_stream_error` — the shipped guard
-//!    (`lance_c::stream_guard::GuardedStream`, wired into both scanner export
-//!    sites in `src/scanner.rs`) catches the same panic in the stream's
-//!    `poll_next` and converts it into one `Some(Err(..))` item, which
-//!    arrow-rs's exported `get_next` maps to a nonzero return +
-//!    `get_last_error`, then end-of-stream. This is exactly the Arrow C
-//!    stream error contract, so C consumers need no changes.
+//! 2. `guarded_stream_maps_panic_to_c_stream_error` — behind the shipped
+//!    guard, the same panic becomes one nonzero `get_next` return +
+//!    `get_last_error`, then end-of-stream: the Arrow C stream error
+//!    contract, so C consumers need no changes.
+//!
+//! 3. `guarded_stream_get_next_inside_tokio_runtime_survives` — regression
+//!    for the review finding that the previous stream-level guard caught too
+//!    late: when the consumer's thread is currently driving a Tokio runtime
+//!    (inside `Runtime::block_on` or a spawned task), `Handle::block_on`
+//!    panics *before any poll*. The unguarded path died
+//!    by SIGABRT here; the reader-level guard must deliver the same error
+//!    contract instead. Runs in a child process: the parent asserts the
+//!    child exits cleanly AND that tokio's panic really fired (caught).
+//!
+//! 4. `guarded_stream_release_drop_panic_survives` — regression for the
+//!    review finding that the release path was unguarded: arrow-rs's
+//!    `release_stream` drops the reader (and the inner stream) inside its
+//!    `extern "C"` callback, so a panicking destructor used to abort the
+//!    host. The guard's `Drop` detaches the inner stream and contains
+//!    cleanup. Runs in a child process, asserting a clean exit AND that
+//!    the destructor panic really fired (caught).
 
 use std::ffi::CStr;
 use std::pin::Pin;
@@ -35,7 +52,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::ffi::FFI_ArrowArray;
 use arrow::ffi_stream::FFI_ArrowArrayStream;
 use futures::Stream;
-use lance_c::stream_guard::GuardedStream;
+use lance_c::stream_guard::GuardedReader;
 use lance_io::ffi::to_ffi_arrow_array_stream;
 use lance_io::stream::RecordBatchStreamAdapter;
 
@@ -70,6 +87,24 @@ impl Stream for PanicOnSecondPoll {
     }
 }
 
+/// A stream whose cleanup panics — simulating a wedged Lance/Arrow
+/// destructor reached from the Arrow C `release` callback.
+struct PanicOnDrop;
+
+impl Stream for PanicOnDrop {
+    type Item = lance_core::Result<RecordBatch>;
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(None)
+    }
+}
+
+impl Drop for PanicOnDrop {
+    fn drop(&mut self) {
+        panic!("simulated Lance bug: panic in stream cleanup");
+    }
+}
+
 /// Drive the exported stream the way a C consumer does: through the raw
 /// `get_next` function pointer, not through any Rust wrapper.
 unsafe fn c_get_next(stream: *mut FFI_ArrowArrayStream, array: *mut FFI_ArrowArray) -> i32 {
@@ -92,6 +127,8 @@ unsafe fn c_get_last_error(stream: *mut FFI_ArrowArrayStream) -> Option<String> 
     }
 }
 
+/// The unguarded export path (lance-io's adaptor): kept for the child-process
+/// test that proves the abort mechanism is real.
 fn export(
     stream: impl lance_io::stream::RecordBatchStream + Unpin + 'static,
 ) -> (tokio::runtime::Runtime, FFI_ArrowArrayStream) {
@@ -100,23 +137,36 @@ fn export(
     (rt, ffi)
 }
 
+/// The shipped export path, mirroring `scanner_to_arrow_stream_inner` and the
+/// async scan task in `src/scanner.rs`: the stream is owned by a
+/// [`GuardedReader`] and exported directly via `FFI_ArrowArrayStream::new`.
+fn guarded_export(
+    stream: impl Stream<Item = lance_core::Result<RecordBatch>> + Unpin + Send + 'static,
+    scanner_poison: Arc<AtomicBool>,
+) -> (tokio::runtime::Runtime, FFI_ArrowArrayStream) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let reader = GuardedReader::new(stream, test_schema(), rt.handle().clone(), scanner_poison);
+    (rt, FFI_ArrowArrayStream::new(Box::new(reader)))
+}
+
+/// Re-run the named test in a child process with `env_var` set, returning
+/// its output for the parent to assert on.
+fn run_child(test_name: &str, env_var: &str) -> std::process::Output {
+    let exe = std::env::current_exe().unwrap();
+    std::process::Command::new(exe)
+        .args([test_name, "--exact", "--nocapture", "--test-threads=1"])
+        .env(env_var, "1")
+        .output()
+        .unwrap()
+}
+
 /// Child-process entry point: export an *unguarded* panicking stream and read
 /// it to the panic. The process is expected to die by SIGABRT.
 #[test]
 fn unguarded_stream_panic_aborts_process() {
     if std::env::var("POC_CHILD").is_err() {
         // Parent mode: re-run this test in a child process and observe how it dies.
-        let exe = std::env::current_exe().unwrap();
-        let output = std::process::Command::new(exe)
-            .args([
-                "unguarded_stream_panic_aborts_process",
-                "--exact",
-                "--nocapture",
-                "--test-threads=1",
-            ])
-            .env("POC_CHILD", "1")
-            .output()
-            .unwrap();
+        let output = run_child("unguarded_stream_panic_aborts_process", "POC_CHILD");
 
         use std::os::unix::process::ExitStatusExt;
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -147,20 +197,16 @@ fn unguarded_stream_panic_aborts_process() {
     std::process::exit(1);
 }
 
-/// Same panicking stream, but behind the shipped `GuardedStream` guard.
+/// Same panicking stream, but behind the shipped [`GuardedReader`] guard.
 /// Verifies the full Arrow C stream error contract end to end, plus the
 /// shared poison flag the guard flips for the owning scanner handle.
 #[test]
 fn guarded_stream_maps_panic_to_c_stream_error() {
     let scanner_poison = Arc::new(AtomicBool::new(false));
-    let stream = RecordBatchStreamAdapter::new(
-        test_schema(),
-        GuardedStream::new(
-            PanicOnSecondPoll { yielded: false },
-            Arc::clone(&scanner_poison),
-        ),
+    let (_rt, mut ffi) = guarded_export(
+        PanicOnSecondPoll { yielded: false },
+        Arc::clone(&scanner_poison),
     );
-    let (_rt, mut ffi) = export(stream);
 
     // 1. First batch arrives normally.
     let mut array = FFI_ArrowArray::empty();
@@ -192,5 +238,115 @@ fn guarded_stream_maps_panic_to_c_stream_error() {
     assert!(
         array2.release.is_none(),
         "end-of-stream must yield a released array"
+    );
+}
+
+/// A `get_next` call made from a thread that is currently driving a Tokio
+/// runtime (inside `Runtime::block_on` or a spawned task — a merely
+/// `enter()`ed context does not trip tokio's check) makes `Handle::block_on`
+/// panic *before any poll* — the previous stream-level guard could not catch
+/// that, and the host died by SIGABRT. The reader-level guard must deliver
+/// the ordinary stream error contract instead. Child mode exits cleanly only
+/// if every assertion holds.
+#[test]
+fn guarded_stream_get_next_inside_tokio_runtime_survives() {
+    if std::env::var("POC_CHILD_RUNTIME").is_err() {
+        // Parent mode: the child must exit cleanly (no SIGABRT), and tokio's
+        // block_on panic must have really fired — caught by the guard, per
+        // the panic hook's stderr output.
+        let output = run_child(
+            "guarded_stream_get_next_inside_tokio_runtime_survives",
+            "POC_CHILD_RUNTIME",
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "guarded child must exit cleanly, got status {:?}\nstderr:\n{stderr}",
+            output.status
+        );
+        assert!(
+            stderr.contains("Cannot start a runtime from within a runtime"),
+            "tokio's runtime-driving panic must have fired (and been caught)\nstderr:\n{stderr}"
+        );
+        return;
+    }
+
+    // Child mode: call the raw get_next pointer from inside a future running
+    // ON the runtime — what a Rust host embedding lance-c would hit.
+    let scanner_poison = Arc::new(AtomicBool::new(false));
+    let (rt, mut ffi) = guarded_export(
+        PanicOnSecondPoll { yielded: false },
+        Arc::clone(&scanner_poison),
+    );
+
+    // The very first get_next panics in `Handle::block_on`, before the stream
+    // is ever polled: the guard maps it to a nonzero return + get_last_error.
+    let mut array = FFI_ArrowArray::empty();
+    let rc = rt.block_on(async { unsafe { c_get_next(&mut ffi, &mut array) } });
+    assert_ne!(
+        rc, 0,
+        "block_on panic must map to a nonzero return code, rc={rc}"
+    );
+    let msg = unsafe { c_get_last_error(&mut ffi) }.expect("get_last_error returned NULL");
+    assert!(
+        msg.contains("runtime"),
+        "expected tokio's panic message via get_last_error, got: {msg}"
+    );
+    assert!(
+        scanner_poison.load(Ordering::SeqCst),
+        "guard must flip the shared scanner poison flag on a block_on panic"
+    );
+
+    // Then the stream is fused: end-of-stream, no second panic.
+    let mut array2 = FFI_ArrowArray::empty();
+    let rc = unsafe { c_get_next(&mut ffi, &mut array2) };
+    assert_eq!(rc, 0, "fused stream must report end-of-stream, rc={rc}");
+    assert!(
+        array2.release.is_none(),
+        "end-of-stream must yield a released array"
+    );
+}
+
+/// A panicking destructor on the `release` path used to unwind out of
+/// arrow-rs's `extern "C" fn release_stream` and abort the host. The guard's
+/// `Drop` detaches the inner stream and contains the cleanup panic
+/// (best-effort: logged, remainder leaked). Child mode exits cleanly only if
+/// `release` returns normally.
+#[test]
+fn guarded_stream_release_drop_panic_survives() {
+    if std::env::var("POC_CHILD_RELEASE").is_err() {
+        // Parent mode: the child must exit cleanly (no SIGABRT), and the
+        // destructor panic must have really fired — caught by the guard, per
+        // the panic hook's stderr output.
+        let output = run_child(
+            "guarded_stream_release_drop_panic_survives",
+            "POC_CHILD_RELEASE",
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "guarded child must exit cleanly, got status {:?}\nstderr:\n{stderr}",
+            output.status
+        );
+        assert!(
+            stderr.contains("simulated Lance bug: panic in stream cleanup"),
+            "the destructor panic must have fired (and been caught)\nstderr:\n{stderr}"
+        );
+        return;
+    }
+
+    // Child mode: invoke the raw release callback the way a C consumer does.
+    let scanner_poison = Arc::new(AtomicBool::new(false));
+    let (_rt, mut ffi) = guarded_export(PanicOnDrop, Arc::clone(&scanner_poison));
+    let release = ffi.release.expect("release callback is NULL");
+    unsafe { release(&mut ffi) };
+
+    assert!(
+        ffi.release.is_none(),
+        "release must be one-shot per the Arrow C stream contract"
+    );
+    assert!(
+        !scanner_poison.load(Ordering::SeqCst),
+        "cleanup panic is best-effort and must not poison the handle"
     );
 }

--- a/tests/panic_stream_guard.rs
+++ b/tests/panic_stream_guard.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Regression tests for issue #61 (panic handling across the FFI boundary).
+//!
+//! Both tests drive the *exact* mechanism a C consumer hits when reading a
+//! `lance_scanner_to_arrow_stream` export (lance-io's
+//! `RecordBatchIteratorAdaptor::next()` runs `handle.block_on(stream.next())`
+//! inside the consumer's `get_next` call):
+//!
+//! 1. `unguarded_stream_panic_aborts_process` — an unguarded stream that
+//!    panics mid-iteration kills the host process even under
+//!    `panic = "unwind"`: the panic unwinds out of arrow-rs's
+//!    `extern "C" fn get_next`, which aborts (Rust 1.81 semantics).
+//!    Runs in a child process so the test suite survives. This deliberately
+//!    exports a raw panicking stream — the mechanism must stay so the test
+//!    keeps proving the gap is real.
+//!
+//! 2. `guarded_stream_maps_panic_to_c_stream_error` — the shipped guard
+//!    (`lance_c::stream_guard::GuardedStream`, wired into both scanner export
+//!    sites in `src/scanner.rs`) catches the same panic in the stream's
+//!    `poll_next` and converts it into one `Some(Err(..))` item, which
+//!    arrow-rs's exported `get_next` maps to a nonzero return +
+//!    `get_last_error`, then end-of-stream. This is exactly the Arrow C
+//!    stream error contract, so C consumers need no changes.
+
+use std::ffi::CStr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
+
+use arrow::array::{Int32Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::ffi::FFI_ArrowArray;
+use arrow::ffi_stream::FFI_ArrowArrayStream;
+use futures::Stream;
+use lance_c::stream_guard::GuardedStream;
+use lance_io::ffi::to_ffi_arrow_array_stream;
+use lance_io::stream::RecordBatchStreamAdapter;
+
+fn test_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]))
+}
+
+fn test_batch() -> RecordBatch {
+    RecordBatch::try_new(
+        test_schema(),
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .unwrap()
+}
+
+/// A stream that yields one batch, then panics on the second poll —
+/// simulating an unwrap/index bug deep in Lance or Arrow scan code.
+struct PanicOnSecondPoll {
+    yielded: bool,
+}
+
+impl Stream for PanicOnSecondPoll {
+    type Item = lance_core::Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if !self.yielded {
+            self.yielded = true;
+            Poll::Ready(Some(Ok(test_batch())))
+        } else {
+            panic!("simulated Lance bug: index out of bounds in scan path");
+        }
+    }
+}
+
+/// Drive the exported stream the way a C consumer does: through the raw
+/// `get_next` function pointer, not through any Rust wrapper.
+unsafe fn c_get_next(stream: *mut FFI_ArrowArrayStream, array: *mut FFI_ArrowArray) -> i32 {
+    let get_next = unsafe { (*stream).get_next }.expect("get_next callback is NULL");
+    unsafe { get_next(stream, array) }
+}
+
+unsafe fn c_get_last_error(stream: *mut FFI_ArrowArrayStream) -> Option<String> {
+    let get_last_error =
+        unsafe { (*stream).get_last_error }.expect("get_last_error callback is NULL");
+    let ptr = unsafe { get_last_error(stream) };
+    if ptr.is_null() {
+        None
+    } else {
+        Some(
+            unsafe { CStr::from_ptr(ptr) }
+                .to_string_lossy()
+                .into_owned(),
+        )
+    }
+}
+
+fn export(
+    stream: impl lance_io::stream::RecordBatchStream + Unpin + 'static,
+) -> (tokio::runtime::Runtime, FFI_ArrowArrayStream) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let ffi = to_ffi_arrow_array_stream(stream, rt.handle().clone()).unwrap();
+    (rt, ffi)
+}
+
+/// Child-process entry point: export an *unguarded* panicking stream and read
+/// it to the panic. The process is expected to die by SIGABRT.
+#[test]
+fn unguarded_stream_panic_aborts_process() {
+    if std::env::var("POC_CHILD").is_err() {
+        // Parent mode: re-run this test in a child process and observe how it dies.
+        let exe = std::env::current_exe().unwrap();
+        let output = std::process::Command::new(exe)
+            .args([
+                "unguarded_stream_panic_aborts_process",
+                "--exact",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env("POC_CHILD", "1")
+            .output()
+            .unwrap();
+
+        use std::os::unix::process::ExitStatusExt;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(
+            output.status.signal(),
+            Some(libc::SIGABRT),
+            "expected SIGABRT, got status {:?}\nstderr:\n{stderr}",
+            output.status
+        );
+        assert!(
+            stderr.contains("panic in a function that cannot unwind"),
+            "expected the Rust 1.81 cannot-unwind abort message\nstderr:\n{stderr}"
+        );
+        return;
+    }
+
+    // Child mode: this process is expected to abort on the second get_next.
+    let stream = RecordBatchStreamAdapter::new(test_schema(), PanicOnSecondPoll { yielded: false });
+    let (_rt, mut ffi) = export(stream);
+    let mut array = FFI_ArrowArray::empty();
+
+    let rc = unsafe { c_get_next(&mut ffi, &mut array) };
+    assert_eq!(rc, 0, "first batch should be delivered fine");
+
+    // The panic unwinds out of arrow-rs's `extern "C" fn get_next` here.
+    unsafe { c_get_next(&mut ffi, &mut array) };
+    eprintln!("UNREACHABLE: process should have aborted before this line");
+    std::process::exit(1);
+}
+
+/// Same panicking stream, but behind the shipped `GuardedStream` guard.
+/// Verifies the full Arrow C stream error contract end to end, plus the
+/// shared poison flag the guard flips for the owning scanner handle.
+#[test]
+fn guarded_stream_maps_panic_to_c_stream_error() {
+    let scanner_poison = Arc::new(AtomicBool::new(false));
+    let stream = RecordBatchStreamAdapter::new(
+        test_schema(),
+        GuardedStream::new(
+            PanicOnSecondPoll { yielded: false },
+            Arc::clone(&scanner_poison),
+        ),
+    );
+    let (_rt, mut ffi) = export(stream);
+
+    // 1. First batch arrives normally.
+    let mut array = FFI_ArrowArray::empty();
+    let rc = unsafe { c_get_next(&mut ffi, &mut array) };
+    assert_eq!(rc, 0, "first batch should be delivered fine, rc={rc}");
+
+    // 2. The panic surfaces as a nonzero return, and get_last_error carries
+    //    the panic message — the Arrow C stream error contract.
+    let rc = unsafe { c_get_next(&mut ffi, &mut array) };
+    assert_ne!(rc, 0, "panic item must map to a nonzero return code");
+    let msg = unsafe { c_get_last_error(&mut ffi) }.expect("get_last_error returned NULL");
+    assert!(
+        msg.contains("simulated Lance bug"),
+        "panic message should propagate to get_last_error, got: {msg}"
+    );
+
+    // 3. The shared poison flag flipped, so the owning scanner handle would
+    //    now reject later calls with LANCE_ERR_PANIC.
+    assert!(
+        scanner_poison.load(Ordering::SeqCst),
+        "guard must flip the shared scanner poison flag on panic"
+    );
+
+    // 4. After the error the stream is fused: get_next reports end-of-stream
+    //    (rc=0 with a released/empty array) instead of panicking again.
+    let mut array2 = FFI_ArrowArray::empty();
+    let rc = unsafe { c_get_next(&mut ffi, &mut array2) };
+    assert_eq!(rc, 0, "fused stream must report end-of-stream, rc={rc}");
+    assert!(
+        array2.release.is_none(),
+        "end-of-stream must yield a released array"
+    );
+}


### PR DESCRIPTION
## Summary

POC implementation of the panic-handling strategy from #61 (consensus of @jja725, @zhangstar333, @u70b3 in the issue discussion):

- **Drop `panic = "abort"`** from the release profile. Under Rust 1.81+ an unwinding panic out of an `extern "C"` fn is a defined abort, never UB — any path we miss can no longer be unsound, only an abort.
- **Catch at every FFI boundary**: all 66 entry points now run under `catch_unwind` — 54 via the extended `ffi_try!` arms (`null` / `neg` / `void` / generic errval, covering the 0-sentinel integer shape), 3 hand-rolled guards on the scanner stream ops, an async task guard plus an entry guard around the async entry's whole call-time setup, 6 `swallow_unwind` close/free paths, and 2 provably infallible TLS accessors. Caught panics map to the new **`LANCE_ERR_PANIC = 9`** (ABI-compatible enum append; matches the header's `LANCE_ERR_*` convention), with the message extracted UniFFI-style (`&str`/`String` downcast, NUL-sanitized).
- **Poisoned scanner handles**: a caught panic flips an `Arc<AtomicBool>` shared with the exported-stream wrapper and the async task; later `lance_scanner_*` calls fail with `LANCE_ERR_PANIC` ("scanner is poisoned by an earlier panic"). `lance_scanner_close` stays poison-check-free so memory is always freed.
- **Dataset handles stay usable** (credit @zhangstar333 for the `RwLock`-poisoning catch): `with_mut` is now clone-execute-swap under the write lock with `catch_unwind` + `resume_unwind` — the panic keeps its original payload for the entry guard, in-memory state rolls back by never swapping, and lock access is poison-tolerant (a single `Arc` pointer swap can never tear).
- **Exported Arrow streams** (the issue's central gap): the stream is exported through a reader-level `GuardedReader` whose `next()` wraps the *complete* `handle.block_on(stream.next())` operation — a stream-level guard catches too late, because `Handle::block_on` itself panics before any poll when the consumer's thread is driving a Tokio runtime. A mid-iteration panic becomes exactly one `Err` item — which arrow-rs's exported `get_next` maps to a nonzero return + `get_last_error`, then EOS, i.e. the Arrow C stream error contract with no C-side changes — and poisons the owning scanner. `GuardedReader::drop` detaches the inner stream and drops it under `catch_unwind`, so a cleanup panic on arrow-rs's `extern "C"` release path is contained (best-effort leak) instead of aborting the host. Worth upstreaming into `lance_io::ffi::to_ffi_arrow_array_stream` so lance-java benefits.
- **Async path**: `DispatcherMessage` now carries `(code, message)`, installed on the dispatcher thread's TLS immediately before each callback (fixes async errors dying on a Tokio worker's TLS — credit @zhangstar333); the whole spawned future runs under `catch_unwind().await`, so a task panic still delivers the `-1` callback instead of hanging the C caller, and poisons the scanner; and the entry guard around call-time setup (validation, scanner building, runtime access, spawn) delivers the same `-1` + poison even when setup itself panics. Host callbacks are explicitly **non-unwinding by contract** (`lance.h`): a panicking `extern "C"` callback aborts at its own boundary before any caller-side guard can run, so the dispatcher's `catch_unwind` is only best-effort protection for `extern "C-unwind"` Rust hosts — never part of the contract.
- **Honest docs** (`lance.h`): double panics, panics in `Drop` during unwind, stack overflow, and allocation failure still abort; close/free (including Arrow stream `release`) is best-effort and may leak the remainder; hosts should fail the query rather than retry a poisoned handle; callbacks passed into the library must not panic.

## Evidence / tests

- `tests/panic_stream_guard.rs` (the PoC from the issue discussion, now tracked): an unguarded export dies by SIGABRT in a child process **even under `panic = "unwind"`**; the guarded export drives the full Arrow C stream error contract end to end through raw `get_next` pointers — including when `get_next` is called from a thread driving a Tokio runtime (where `Handle::block_on` panics before any poll) — and a panicking destructor reached through the raw `release` pointer is contained. Both child-process regressions assert a clean exit AND that the panic really fired (via the panic hook's stderr).
- Rust unit tests covering: guard-arm shapes, poison behavior on all scanner entry-point shapes, `with_mut` rollback on a genuinely poisoned lock, dispatcher TLS transport + stale-error clearing, reader-level fusing / NUL sanitization / runtime-driving-thread containment / drop containment, and an injectable-setup test proving a `scan_async` setup panic poisons the handle and dispatches exactly one `LANCE_ERR_PANIC` completion.
- Full suite: **296 passed / 0 failed**; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt` clean; C/C++ compile-and-run tests pass (GCC 13.3.0).

## Deliberate minor bugfixes folded in

- `lance_dataset_version` now clears the thread-local error on success, like every other guarded fn.
- `lance_dataset_write` wraps the shared inner directly instead of bare-forwarding to `lance_dataset_write_with_params` (an outer guard would have cleared the inner guard's TLS error).

## Out of scope / follow-ups

- Index segment builders (`src/index_segment.rs`) live on the unmerged distributed-index branch; they need the same poison treatment once that lands.
- Upstreaming `GuardedReader` into lance-io so lance-java benefits too.
- Optional chained panic hook for backtraces (the default hook already prints to stderr).
